### PR TITLE
feat: add dev-runtime lifecycle entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Agent 必须扫描目标仓库实际存在的 Skill 目录，先读取每个候�
 
 | Skill | 主要用途 | 典型触发语句 | 是否允许修改文件 | 是否需要项目初始化 | 依赖档案或 reference | 不适用场景 |
 | --- | --- | --- | --- | --- | --- | --- |
+| `dev-runtime` | 完整开发请求的统一阶段路由；动态发现已安装 Skill，先规划，再按 handoff、实现单元数量和当前任务意图切换实现、测试与代码检查 | “开发一个应用”“开始完整开发”“继续开发并按流程推进” | 自身只路由，不直接修改业务文件；实际权限由当前选中的阶段 Skill 或小任务普通 Agent 分支决定 | 否；不建立自己的 Runtime，复用各阶段真实输入与交接 | 当前项目的 Skill 发现信息、`planning-layer-runtime`、可选的 long/testing/inspection 交接 | 单一阶段请求、无需正式生命周期的零散小改、发布批准或生产门禁 |
 | `ai-code-inspection` | 按 10 种真实工作场景路由通用代码检查、诊断、只读审计、已确认 Bug/紧急补丁闭环和受控规范矫正 | “检查当前 Git 变更”“定位这个报错”“核查需求是否实现完整”“修复这个已确认 Bug”“检查 PR 合并准备”“按规范矫正这些文件” | 依场景决定；场景 1–9 单次完成，只有场景 10 交互执行七步；代码与真实数据库权限独立 | 是；首次使用从模板初始化项目级 `.runtime/ai-code-inspection/` | 项目级环境档案和 Runtime、Step references、按需 Profiles | 上线发布、生产门禁、严格安全验收、无准入的猜测修复或大规模重构 |
 | `planning-layer-runtime` | 实现前的业务发现、Planning Context、正式规划文档和 planning handoff | “先做开发规划”“创建这一期规划文档”“梳理需求和验收边界” | 仅允许其定义的项目级规划启动上下文、正式规划文档与 planning runtime；不改生产代码 | 是；按需建立最小 `.runtime/planning-layer-runtime/`，并绑定目标项目已有的正式规划目录与当前事实基线路径 | `references/00`–`10`、`.runtime/planning-layer-runtime/`、项目当前基线和正式规划目录 | 直接实现、测试执行、发布或生产操作 |
 | `long-task-orchestrator` | 根据已确认 handoff 执行至少 4 个实现单元的完整功能，并交付到 `ready_for_local_test`；也处理已确认缺陷 patch | “按已确认计划完成这个模块”“继续长任务实现并写自动化测试”“修复 testing 已确认缺陷” | 通过 Source of Truth 与 Runtime Gate 后可修改实现、测试和其 Runtime 资产 | 是；必须确认 handoff、通过 preflight 并创建/恢复 Phase Runtime Directory | Runtime kernel references、planning handoff、Phase Runtime Directory | 小于 4 个实现单元、缺少已确认 SoT、人工验收、云端验证、上线放行 |
@@ -75,12 +76,13 @@ Agent 第一次在目标项目使用需要环境事实的 Skill 时，先执行�
 
 多个 Skill 都可能适用时：
 
+- 完整或模糊的端到端开发请求优先由 `dev-runtime` 负责阶段路由；它不取代当前阶段 Skill 的 Runtime、权限和 handoff。
 - 选择职责最直接的 Skill 作为当前主治理 Skill。
 - 不让检查 Skill 承担规划、发布或安全验收。
 - 不让规划 Skill 直接修改生产代码。
 - 不让实现 Skill 代替人工验收，也不让测试 Skill 重新承担开发期自动化。
 - 不让发布流程代替日常代码检查。
-- 必要时按 `planning → implementation → testing → 项目发布/安全流程` 顺序切换；每个阶段只保留一个主治理 Skill，完成明确 handoff 后再切换。
+- 必要时由 `dev-runtime` 按 `planning → implementation → testing → 可选代码检查场景 → 项目发布/安全流程` 顺序切换；每个阶段只保留一个主治理 Skill，完成明确 handoff 后再切换。
 
 ## 6. 项目适配原则
 
@@ -144,4 +146,6 @@ Agent 第一次在目标项目使用需要环境事实的 Skill 时，先执行�
 使用 ai-code-inspection 对当前项目做全量只读审计。
 
 使用适合的 Skill 处理这个任务，并先说明选择理由和执行边界。
+
+使用 dev-runtime 处理这个完整开发请求；动态发现已安装 Skill，并遵守每个阶段当前的进入和交接门禁。
 ```

--- a/README.md
+++ b/README.md
@@ -6,27 +6,33 @@ A project-neutral set of Agent Skills for planning, implementation, testing, and
 
 Only the selected directories under `skills/` are installable Skill packages. `AGENTS.md` is the reusable project-entry template. `src/`, `public/`, `package*.json`, `astro.config.mjs`, `tsconfig.json`, and the documentation deployment workflow belong to this repository's Astro/Starlight documentation site and must not be copied into a target project.
 
-## The four skills
+## The five skills
 
 | Skill | Use it for | Boundary |
 | --- | --- | --- |
+| [`dev-runtime`](skills/dev-runtime/SKILL.md) | Route complete or vague development requests across the installed Runtime Skills, starting with planning and preserving each current entry and handoff gate. | Does not replace phase governance, handle single-stage requests, assume a fixed Skill directory, or approve release. Work below four implementation units uses the normal Agent path instead of long-task orchestration. |
 | [`planning-layer-runtime`](skills/planning-layer-runtime/SKILL.md) | Discover requirements and produce an approved planning handoff before implementation. | Does not write production code or execute tests. |
 | [`long-task-orchestrator`](skills/long-task-orchestrator/SKILL.md) | Implement an approved feature with at least four implementation units, run automation, and hand off at `ready_for_local_test`. | Does not perform manual acceptance or release approval. |
 | [`testing-layer-runtime`](skills/testing-layer-runtime/SKILL.md) | Reuse long-task automation evidence and manage manual, device, server, external-capability, and final acceptance testing. | Does not change business code or approve production release. |
 | [`ai-code-inspection`](skills/ai-code-inspection/SKILL.md) | Route reviews, diagnosis, confirmed fixes, completeness checks, audits, refactor assessments, merge checks, hotfixes, and standards governance by ten real work scenarios. | Scenarios 1–9 are single-run; only standards governance uses the interactive seven-step flow. Project state lives under `.runtime/ai-code-inspection/`. It is not a release or security gate. |
 
-The normal delivery chain is:
+For a complete request, `dev-runtime` discovers the installed Skills and routes the delivery chain:
 
 ```text
-planning-layer-runtime
+dev-runtime
+  -> planning-layer-runtime
   -> approved handoff
-  -> long-task-orchestrator
-  -> ready_for_local_test
-  -> testing-layer-runtime
+  -> planning_only: stop after planning
+  -> execution_ready with fewer than 4 implementation units: normal Agent implementation and project validation
+  -> execution_ready with at least 4 implementation units:
+     long-task-orchestrator
+     -> ready_for_local_test
+     -> testing-layer-runtime
+  -> optional ai-code-inspection scene selected from the actual request
   -> the target project's release/security process
 ```
 
-`ai-code-inspection` is independent and can be used for focused review, diagnosis, confirmed repair, requirement-completeness review, audit, refactor assessment, merge readiness, hotfix closure, or standards governance.
+`ai-code-inspection` is independent and can be used for focused review, diagnosis, confirmed repair, requirement-completeness review, audit, refactor assessment, merge readiness, hotfix closure, or standards governance. Scenarios 1–9 are `single_run`; only `standards_compliance_correction` uses the interactive seven-step flow.
 
 ## Install in an Agent project
 
@@ -48,17 +54,21 @@ your-project/
 ├── CLAUDE.md                   # only needed by Claude Code
 ├── .agents/skills/             # Codex + GitHub Copilot
 │   ├── ai-code-inspection/
+│   ├── dev-runtime/
 │   ├── planning-layer-runtime/
 │   ├── long-task-orchestrator/
 │   └── testing-layer-runtime/
 └── .claude/skills/             # Claude Code
     ├── ai-code-inspection/
+    ├── dev-runtime/
     ├── planning-layer-runtime/
     ├── long-task-orchestrator/
     └── testing-layer-runtime/
 ```
 
 The Agent installs only the directories required by the selected platforms. If the target project already has `AGENTS.md` or `CLAUDE.md`, it merges the instructions instead of overwriting them. When only some Skills are installed, it removes unavailable Skills from the installed `AGENTS.md` inventory.
+
+For the complete lifecycle, install `dev-runtime` together with the four phase Skills it discovers. If a phase Skill is not installed, `dev-runtime` reports the missing dependency instead of guessing a path or pretending the phase ran.
 
 Claude Code does not read `AGENTS.md` directly. The Agent therefore creates or merges this minimal project file:
 
@@ -97,6 +107,8 @@ AI initialization means locating the named target, installing the selected Skill
 Use natural language or invoke the skill explicitly where the agent supports it. Codex exposes skills through `/skills` or `$skill-name`; Claude Code uses `/skill-name`; Copilot selects skills from the request and the skill description.
 
 ```text
+Use dev-runtime to route this complete development request through the installed Runtime Skills.
+
 Use planning-layer-runtime to plan this feature. Do not implement it yet.
 
 Use long-task-orchestrator to execute the approved planning handoff.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,27 +6,33 @@
 
 只有 `skills/` 下被选中的目录属于可安装 Skill 包；`AGENTS.md` 是可复用的项目入口模板。`src/`、`public/`、`package*.json`、`astro.config.mjs`、`tsconfig.json` 和文档部署 workflow 只用于构建本仓库的 Astro/Starlight 文档站，不能复制到目标项目。
 
-## 四个 Skill
+## 五个 Skill
 
 | Skill | 适用任务 | 边界 |
 | --- | --- | --- |
+| [`dev-runtime`](skills/dev-runtime/SKILL.md) | 为完整或模糊开发请求动态发现并路由已安装的 Runtime Skill；先进入规划，并保留各阶段当前的进入和交接门禁。 | 不替代阶段治理，不处理单一阶段请求，不假设固定 Skill 目录，也不批准发布；少于 4 个实现单元时使用普通 Agent 分支，不强行进入 long。 |
 | [`planning-layer-runtime`](skills/planning-layer-runtime/SKILL.md) | 开发前梳理需求并产出已确认的规划交接。 | 不写生产代码，不执行测试。 |
 | [`long-task-orchestrator`](skills/long-task-orchestrator/SKILL.md) | 根据已确认规划实现至少 4 个实现单元，执行自动化验证，并交接到 `ready_for_local_test`。 | 不负责人工验收和上线批准。 |
 | [`testing-layer-runtime`](skills/testing-layer-runtime/SKILL.md) | 继承 long 的自动化证据，管理人工、设备、服务器、外部能力和最终验收。 | 不修改业务代码，不批准生产上线。 |
 | [`ai-code-inspection`](skills/ai-code-inspection/SKILL.md) | 按 10 种真实工作场景路由改动检查、根因诊断、确认修复、完整性核查、审计、重构评估、合并检查、hotfix 和规范治理。 | 场景 1–9 单次完成；只有规范治理使用交互式七步。项目运行态位于 `.runtime/ai-code-inspection/`。它不是发布或安全门禁。 |
 
-正常开发链路：
+完整请求由 `dev-runtime` 动态发现已安装 Skill，并按以下链路分流：
 
 ```text
-planning-layer-runtime
+dev-runtime
+  -> planning-layer-runtime
   -> 已确认规划交接
-  -> long-task-orchestrator
-  -> ready_for_local_test
-  -> testing-layer-runtime
+  -> planning_only：规划完成后停止
+  -> execution_ready 且少于 4 个实现单元：普通 Agent 实现并执行项目验证
+  -> execution_ready 且至少 4 个实现单元：
+     long-task-orchestrator
+     -> ready_for_local_test
+     -> testing-layer-runtime
+  -> 按实际请求选择可选的 ai-code-inspection 场景
   -> 目标项目自己的发布/安全流程
 ```
 
-`ai-code-inspection` 是独立流程，可单独用于代码检查、根因诊断、确认修复、需求完整性核查、审计、重构评估、合并准备、hotfix 或规范治理。
+`ai-code-inspection` 是独立流程，可单独用于代码检查、根因诊断、确认修复、需求完整性核查、审计、重构评估、合并准备、hotfix 或规范治理。场景 1–9 使用 `single_run`；只有 `standards_compliance_correction` 使用交互式七步。
 
 ## 部署到 Agent 项目
 
@@ -48,17 +54,21 @@ your-project/
 ├── CLAUDE.md                   # 仅 Claude Code 需要
 ├── .agents/skills/             # Codex + GitHub Copilot
 │   ├── ai-code-inspection/
+│   ├── dev-runtime/
 │   ├── planning-layer-runtime/
 │   ├── long-task-orchestrator/
 │   └── testing-layer-runtime/
 └── .claude/skills/             # Claude Code
     ├── ai-code-inspection/
+    ├── dev-runtime/
     ├── planning-layer-runtime/
     ├── long-task-orchestrator/
     └── testing-layer-runtime/
 ```
 
 Agent 只安装所选平台需要的目录。目标项目已有 `AGENTS.md` 或 `CLAUDE.md` 时，由 Agent 合并指令而不是覆盖；只安装部分 Skill 时，由 Agent 从安装后的 `AGENTS.md` 清单中移除未安装项。
+
+使用完整生命周期时，需要同时安装 `dev-runtime` 和它动态发现的四个阶段 Skill。某个阶段 Skill 未安装时，`dev-runtime` 必须报告缺失依赖，不猜测路径，也不假装该阶段已经执行。
 
 Claude Code 不会直接读取 `AGENTS.md`，因此 Agent 会创建或合并这个最小项目文件：
 
@@ -97,6 +107,8 @@ AI 初始化只包括：定位指定目标、安装选中的 Skill 包、合并 
 可以直接使用自然语言；支持显式调用的平台也可以直接点名 Skill。Codex 可通过 `/skills` 或 `$skill-name` 调用，Claude Code 使用 `/skill-name`，Copilot 根据请求和 Skill 描述自动选择。
 
 ```text
+使用 dev-runtime，让这个完整开发请求通过已安装的 Runtime Skill 按门禁推进。
+
 使用 planning-layer-runtime 规划这个功能，暂时不要实现。
 
 使用 long-task-orchestrator 执行已经确认的规划交接。

--- a/skills/dev-runtime/SKILL.md
+++ b/skills/dev-runtime/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: dev-runtime
+description: 完整开发生命周期的统一路由入口。用户提出“开发某某应用”“做一个某某系统”“开始开发”“继续开发”或其他端到端开发请求时使用；即使请求模糊，也先进入 planning-layer-runtime。Planning Handoff Complete 后，至少 4 个实现单元的 execution_ready 工作交给 long-task-orchestrator，再按有效交接进入 testing-layer-runtime；少于 4 个实现单元时改由普通 Agent 按已确认范围实现和验证。需要代码检查、诊断、修复、审计或规范治理时，按 ai-code-inspection 当前 10 种场景路由。明确只要求单一阶段时直接使用对应 Skill。
+---
+
+# Dev Runtime
+
+`dev-runtime` 负责完整开发请求的阶段选择与交接，不建立第二套 planning、implementation、testing 或 inspection Runtime。每个阶段开始前动态发现并完整读取对应 Skill；阶段内部状态、权限、产物和门禁只由该 Skill 定义。
+
+## 使用范围
+
+使用本 Skill：
+
+- 用户要求从模糊想法开始完成一个应用、系统、功能或完整开发任务。
+- 用户说“开始开发”“继续开发”“走完整流程”，但当前阶段或交接状态不清楚。
+- 需要在 planning、implementation、testing 和代码检查之间按真实交接顺序推进。
+
+不使用本 Skill：
+
+- 用户明确只要求规划、实现、测试、代码检查、诊断、修复、审计或规范治理中的单一阶段；直接选择职责最匹配的 Skill。
+- 只是无需正式规划和测试生命周期的零散小改；使用普通 Agent 指令。
+- 发布批准、生产门禁或严格安全验收；交给目标项目自己的流程。
+
+## 动态发现同级 Skill
+
+不得假设 Skill 安装在仓库根目录 `skills/`，也不得写死 `.agents/skills/`、`.claude/skills/`、`.github/skills/` 或其他平台目录。
+
+每次需要切换阶段时：
+
+1. 读取当前项目有效的 `AGENTS.md`、平台 Skill 清单或等价发现信息。
+2. 扫描项目实际安装的 Skill 目录，并读取候选 `SKILL.md` frontmatter。
+3. 按 `name` 精确查找 `planning-layer-runtime`、`long-task-orchestrator`、`testing-layer-runtime` 或 `ai-code-inspection`。
+4. 只完整读取当前阶段选中的 `SKILL.md`，再按它自己的路由加载必要 references、Profiles、模板和项目 Runtime。
+5. Skill 缺失、重名、路径不确定或未安装时停止并报告；不得猜测路径、复制内嵌副本或假装已触发。
+
+## 生命周期路由
+
+```text
+dev-runtime
+-> planning-layer-runtime
+-> Planning Handoff Complete
+-> handoff_type / implementation-unit gate
+
+planning_only
+-> STOP: planning completed, no implementation handoff
+
+execution_ready + implementation units < 4
+-> normal Agent implementation and project validation
+-> optional ai-code-inspection scene selected from the actual request
+-> target project's own release/security process
+
+execution_ready + implementation units >= 4
+-> long-task-orchestrator
+-> ready_for_local_test or ready_for_local_retest
+-> testing-layer-runtime
+-> release handoff
+-> optional ai-code-inspection scene selected from the actual request
+-> target project's own release/security process
+```
+
+“optional” 表示只有当前任务目标需要代码检查、诊断、修复、完整性核查、审计、重构评估、合并准备、hotfix 或规范治理时才进入 `ai-code-inspection`。不得为了让流程看起来完整而强制运行不匹配的场景。
+
+## Planning 阶段
+
+完整或模糊开发请求先使用 `planning-layer-runtime`：
+
+- 需求不完整时停留在规划访谈和逐文档确认，不得直接实现。
+- 只有 Planning Context、正式文档、最终人话总结和用户确认满足当前 planning Skill 的门禁后，才接受 `Planning Handoff Complete`。
+- `handoff_type: planning_only` 时停止完整开发流程，不得交给实现 Skill。
+- `handoff_type: execution_ready` 时读取已确认的 Development Landing Checklist、TASK 或等价实现清单，计算真实实现单元数量。
+
+不得为了满足 long 的门禁而人为拆碎任务。实现单元数量必须来自 planning 已确认的真实任务边界。
+
+## 实现分流
+
+### 至少 4 个实现单元
+
+只有同时满足以下条件，才进入 `long-task-orchestrator`：
+
+- Handoff 已确认且未失效。
+- `handoff_type: execution_ready` 且 `requires_execution_handoff: true`。
+- 当前 long Skill 要求的正式职责、真实路径、`execution_constraints` 和 P0 门禁完整。
+- 已确认工作至少包含 4 个真实实现单元。
+
+进入后完全遵守 long 的 Intake Gate、Runtime Gate、自动化验证和 Long Testing Handoff。只有产生 `ready_for_local_test` 或 `ready_for_local_retest` 后，才允许切换到 testing。
+
+### 少于 4 个实现单元
+
+少于 4 个实现单元不属于 `long-task-orchestrator` 范围：
+
+1. 保留 planning 已确认的范围、约束、验收标准和 Source of Truth。
+2. 停止 long 路由，不创建 long Runtime，不产生或伪造 `ready_for_local_test`。
+3. 由普通 Agent 按项目指令完成精确实现，并运行目标项目已有的适用 build、test、lint、typecheck、schema 或契约验证。
+4. 明确报告未运行 long 和 testing 生命周期；没有有效 Long Testing Handoff 时不得触发 `testing-layer-runtime`。
+5. 如用户还要求代码检查、合并准备或其他治理，按实际意图选择 `ai-code-inspection` 场景；否则移交目标项目自己的后续流程。
+
+## Testing 阶段
+
+只有存在有效 Long Testing Handoff，且 long 已达到 `ready_for_local_test` 或 `ready_for_local_retest` 时，才进入 `testing-layer-runtime`。
+
+- testing 继承 long 已通过且证据有效的自动化结果，不为重复拿到“通过”而重跑。
+- testing 负责人工、真实设备、服务器、云端、外部能力和最终验收，以及 release handoff。
+- testing 不修改业务代码，也不批准生产发布。
+- testing 发现开发缺陷时，按当前 testing 和 long Skill 的缺陷交接规则返回 long patch；不得由 dev-runtime 自创修复状态。
+
+## AI Code Inspection 路由
+
+使用 `ai-code-inspection` 前必须重新读取其当前 `SKILL.md` 并按完整语义选择场景。当前规则包含 10 个用户场景：
+
+- 场景 1–9 使用 `single_run`，在各自范围与权限内一次完成，并只输出一次最终报告。
+- 场景 6 虽内部完整执行 Step 1–7，仍是一次性只读审计，不是交互 gate。
+- 只有场景 10 `standards_compliance_correction` 使用 `interactive_seven_step`。
+- 普通“检查当前改动”进入 `changed_code_review`，不是七步交互治理。
+- 明确 Bug 修复、需求完整性、全项目审计、合并准备或 hotfix 分别使用对应场景，不得统一压成一个“最终检查”。
+
+`dev-runtime` 不复制十场景规则、不替场景授予修改权限，也不把普通 `继续` 解释为修复授权。场景执行完后，按 ai-code-inspection 的最终报告和建议后续场景决定是否结束、转入其他场景或返回前一阶段。
+
+## 阶段切换门禁
+
+1. 当前 Skill 未明确达到自己的交接条件时，不读取或执行下一阶段 Skill。
+2. 用户态回复以问题、确认请求、范围纠偏或阻塞项收口时，本轮停止，不在同一轮越过用户确认。
+3. 切换阶段前撤销上一阶段的临时权限；读取权限不自动成为修改权限。
+4. 任一 Skill 缺失、输入不合法、Runtime 不一致、证据不足或环境条件缺失时，停止在当前阶段并报告唯一下一步。
+5. 不得用普通待办、自然语言承诺、代码存在或自动化通过，替代正式 Skill 触发和 handoff。
+
+## 最终报告
+
+结束或阻塞时报告：
+
+- `planning-layer-runtime`：未触发、进行中、已完成、`planning_only` 或阻塞原因。
+- 实现分支：普通 Agent（少于 4 个实现单元）或 `long-task-orchestrator`（至少 4 个实现单元），以及真实验证状态。
+- `testing-layer-runtime`：未适用、未触发、进行中、已完成或阻塞原因。
+- `ai-code-inspection`：未适用，或实际选择的 `scene_id`、strategy、是否修改文件和结论。
+- release/security：只说明移交状态，不宣称本仓库已经批准上线。
+
+不得暗示未读取的 Skill、未执行的验证或未满足的门禁已经完成。
+
+## 安全边界
+
+- 保留与当前任务无关的工作区改动。
+- 未经用户明确要求，不执行 stage、commit、push、reset、checkout、stash、部署、数据库迁移、真实数据修改、密钥修改或生产操作。
+- 通用 Skill 源文件不得写入目标项目的身份、路径、账号、服务器、密钥或环境事实。

--- a/skills/dev-runtime/agents/openai.yaml
+++ b/skills/dev-runtime/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Dev Runtime"
+  short_description: "Route complete development through installed Runtime Skills."
+  default_prompt: "Use $dev-runtime to discover the installed Runtime Skills, plan this request, and route each eligible stage without bypassing its current handoff gates."

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -5,7 +5,7 @@ description: 学习如何在 Codex 项目中组织规划、开发、测试和日
 
 import { Card, CardGrid, Steps } from '@astrojs/starlight/components';
 
-这套教程围绕仓库中的四个 Runtime Skill 展开。你可以从完整流程开始，也可以只使用独立的代码检查流程。
+这套教程围绕仓库中的五个 Runtime Skill 展开。完整或模糊开发请求可以使用 `dev-runtime` 统一路由，也可以直接使用单一阶段 Skill。
 
 ## 开发主流程
 

--- a/src/content/docs/reference/skill-catalog.md
+++ b/src/content/docs/reference/skill-catalog.md
@@ -1,9 +1,16 @@
 ---
 title: Skill 目录
-description: 四个 Runtime Skill 的用途、入口和规则源文件。
+description: 五个 Runtime Skill 的用途、入口和规则源文件。
 ---
 
 教程用于解释常见使用方式。实际执行必须先完整读取对应入口，再按照入口路由读取本次任务需要的 references。
+
+## dev-runtime
+
+- 用途：完整或模糊开发请求的统一阶段路由；先规划，再按真实 handoff、实现单元数量和当前任务意图切换实现、测试与代码检查。
+- 入口：[`skills/dev-runtime/SKILL.md`](https://github.com/xinghang-ee-cs/dev-runtime-skill/blob/main/skills/dev-runtime/SKILL.md)
+- 路径：运行时动态发现同级 Skill，不假设 `.agents/skills/`、`.claude/skills/` 或其他固定安装目录。
+- 不负责：复制阶段规则、建立第二套 Runtime、处理单一阶段请求、批准发布或生产操作。
 
 ## planning-layer-runtime
 


### PR DESCRIPTION
## Summary

- add `dev-runtime` as the unified router for complete or vague development requests
- dynamically discover installed sibling Skills instead of assuming `skills/`, `.agents/skills/`, `.claude/skills/`, or any fixed directory
- preserve each current planning, long-task, testing, and ai-code-inspection entry/handoff gate
- route execution-ready work with fewer than four implementation units through the normal Agent path instead of forcing long-task orchestration
- align inspection routing with the current ten scenes: scenes 1–9 are `single_run`; only `standards_compliance_correction` uses the interactive seven-step flow
- register `dev-runtime` in the root `AGENTS.md`, both multi-platform READMEs, the documentation home, and the documentation-site Skill catalog

## Owner feedback addressed

1. Rebased onto the latest upstream `main` and preserved the current Codex / Claude Code / GitHub Copilot installation flow.
2. Added `dev-runtime` to the root `AGENTS.md` and documentation-site Skill catalog.
3. Removed fixed sibling Skill paths; runtime discovery uses installed Skill metadata and project instructions.
4. Updated the orchestration contract to the current ten `ai-code-inspection` scenes and execution strategies.
5. Added an explicit `< 4 implementation units` normal-Agent branch with no fake long Runtime or Long Testing Handoff.
6. Removed unsupported `interface.description`; `agents/openai.yaml` now contains only `display_name`, `short_description`, and `default_prompt`.

## Validation

- `npm run check`: 0 errors, 0 warnings, 0 hints
- `npm run build`: 7 documentation pages built successfully
- `git diff --check`: passed
- committed-content validation: all six owner requirements passed
- privacy scan of changed files: no findings
- existing four phase Skill source files remain unchanged
