### PR TITLE
feat(planning): 增强 Discovery 持久化、跨期需求池与事实调研

### DIFF
--- a/skills/planning-layer-runtime/SKILL.md
+++ b/skills/planning-layer-runtime/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: planning-layer-runtime
-description: 交互式规划层运行时。用于读取目标项目当前基线、开展规划访谈、创建 Planning Context，创建、更新、审查和修复目标项目正式规划目录下的开发规划文档，以及在规划、执行、测试或验收阶段对新增需求、规划遗漏、设计漂移和变更回流进行范围准入、精确失效传播、增量任务合同与增量 Handoff。覆盖完整一期从当前事实、00–13、Planning Execution Baseline、14/15 框架、执行交接，到实际发布后项目基线更新和期次关闭的规划合同；不能填写测试代码、命令、执行状态、实际测试结果、验收或发布事实。
+description: 交互式规划层运行时。用于读取目标项目当前基线、在第一阶段先核实可查事实并逐轮持久化规划访谈、维护跨期需求池、创建 Planning Context，创建、更新、审查和修复目标项目正式规划目录下的开发规划文档，以及在规划、执行、测试或验收阶段对新增需求、规划遗漏、设计漂移和变更回流进行范围准入、精确失效传播、增量任务合同与增量 Handoff。覆盖完整一期从当前事实、00–13、Planning Execution Baseline、14/15 框架、执行交接，到实际发布后项目基线更新和期次关闭的规划合同；不能填写测试代码、命令、执行状态、实际测试结果、验收或发布事实。
 ---
 
 # 规划层运行时（Planning Layer Runtime）
@@ -13,14 +13,14 @@ description: 交互式规划层运行时。用于读取目标项目当前基线�
 
 只读取当前任务需要的文件：
 
-- `references/00-planning-user-discovery.md`：用户发现访谈、业务事实发现、专业词翻译和 Discovery Sufficiency Gate。
-- `references/01-planning-core-rules.md`：规划层核心约束、完整一期事实链、Planning Execution Baseline 与 Change Set 唯一承载边界、项目当前基线与前端体验事实、期次关闭、Planning 追踪 ID 与实现命名隔离。
+- `references/00-planning-user-discovery.md`：用户发现访谈、逐轮发现检查点、本地与公开事实调研、功能候选补充、业务事实发现、专业词翻译和 Discovery Sufficiency Gate。
+- `references/01-planning-core-rules.md`：规划层核心约束、跨期需求池边界、完整一期事实链、Planning Execution Baseline 与 Change Set 唯一承载边界、项目当前基线与前端体验事实、期次关闭、Planning 追踪 ID 与实现命名隔离。
 - `references/02-planning-change-levels.md`：变更影响分级、期内范围扩展准入、多 Change Set 生命周期、冻结基线后的增量执行选择与 carried-forward pending 任务保护。
 - `references/03-planning-doc-responsibility.md`：文档清单、职责、上游 SoT、下游输出和禁止内容。
-- `references/04-planning-format-spec.md`：AI Runtime 文件位置、ARCH 实现承接策略、TASK 命名与实现参数状态、`current-interaction.yaml`、ID、引用和验收结构。
+- `references/04-planning-format-spec.md`：AI Runtime 文件位置、需求池格式、ARCH 实现承接策略、TASK 命名与实现参数状态、`current-interaction.yaml`、ID、引用和验收结构。
 - `references/05-planning-priority-system.md`：规划优先级、严重性、发布阻塞与下游验证门禁语义。
 - `references/06-planning-capability-governance.md`：外部能力、SDK、OpenAPI、MCP、AI 提供方、官方 SoT、证据门禁与 Runtime 门禁治理。
-- `references/07-planning-conversation-runtime.md`：Planning Conversation 行为运行层；维护完整一期生命周期、三个变更门禁编排、Planning Execution Baseline 冻结、Implementation Naming / Contract Completeness Gate、增量 Handoff 完整性、前端体验绑定和期次关闭。
+- `references/07-planning-conversation-runtime.md`：Planning Conversation 行为运行层；编排逐轮持久化、事实调研、需求池核对、完整一期生命周期、三个变更门禁、Planning Execution Baseline 冻结、Implementation Naming / Contract Completeness Gate、增量 Handoff 完整性、前端体验绑定和期次关闭。
 - `references/08-planning-recovery-runtime.md`：上下文压缩与中断恢复、Change Triage 后的精确 Planning Recovery、失效传播、恢复门禁、Runtime Audit 日志与用户隔离。
 - `references/09-execution-intent-guard.md`：Execution Boundary Kernel。所有输入的 execution intent 判定、阻断结果和语义转向规则的唯一事实来源。
 - `references/10-planning-document-interaction-runtime.md`：Planning Document Mode 的用户反馈事务、逐文档交互、13 开发前准备总结、最终人话总结确认和状态回写规则。
@@ -31,6 +31,7 @@ description: 交互式规划层运行时。用于读取目标项目当前基线�
 
 ```yaml
 planning_root: <项目正式规划根目录>
+requirement_pool_path: <planning_root>/REQUIREMENT-POOL.md
 phase_planning_directory: <当前规划期次或工作包目录>
 phase_planning_runtime_directory: <phase_planning_directory>/planning-runtime
 project_current_baseline_path: <项目当前事实基线文件>
@@ -40,8 +41,9 @@ project_current_baseline_path: <项目当前事实基线文件>
 
 - 优先复用目标项目已有规划目录、期次组织方式和当前事实文件。
 - 若项目尚无对应位置，只在本次职责确实需要时创建最小项目级路径，并将真实路径写入 `.runtime/planning-layer-runtime/project-profile.yaml` 或当前 Planning Context。
+- 优先复用项目正式规划根目录下已有的需求池等价文件；不存在时，`<requirement_pool_path>` 绑定为 `<planning_root>/REQUIREMENT-POOL.md`，仅在第一次真实写入延期需求时创建，不预建空文件。
 - 路径选择必须来自目标项目事实，不得默认使用本 Skill 来源项目的目录、期次名称或文档位置。
-- `<planning_root>`、`<phase_planning_directory>`、`<phase_planning_runtime_directory>` 与 `<project_current_baseline_path>` 仅是静态规则中的语义占位符；写入项目前必须解析为真实路径。
+- `<planning_root>`、`<requirement_pool_path>`、`<phase_planning_directory>`、`<phase_planning_runtime_directory>` 与 `<project_current_baseline_path>` 仅是静态规则中的语义占位符；写入项目前必须解析为真实路径。
 - 目标位置唯一且可从仓库事实确认时直接绑定；存在多个候选、缺少写入权限或会改变已有 SoT 归属时，停止并请求用户确认。
 - 路径绑定只改变产物落点，不改变 Planning Context、Document Assembly、Handoff、Gate、确认与恢复流程。
 
@@ -139,6 +141,23 @@ project_current_baseline_path:
 - Flow Contract 与 Journey-Object Map 格式见 `references/04-planning-format-spec.md`。
 - 基线、FLOW 和对象地图变化的失效传播见 `references/08-planning-recovery-runtime.md`。
 
+## Cross-Phase Requirement Pool
+
+跨期待处理需求的唯一项目级入口：
+
+```text
+<requirement_pool_path>
+```
+
+定位：
+
+- 保存已由用户确认、但明确不进入当前期次的需求。
+- 是下一期 Discovery 的历史需求佐证，不是项目当前事实、正式业务 SoT、Planning Context、TASK、Handoff 或执行 Backlog。
+- 延期决定一旦确认，必须在继续下一轮讨论前立即写入；不得等 15、Handoff、总结或本期结束时再补记。
+- 非第一次 Planning 启动时按 `references/07-planning-conversation-runtime.md` 读取并与用户当前想法做语义比较。
+- 同一需求在确认纳入当前期后删除对应池条目；冲突需求先按用户最新确认更新池条目，再继续范围判断；无关条目保持不变且不打扰当前对话。
+- 唯一格式、去重、更新、删除和引用规则见 `references/04-planning-format-spec.md`。
+
 ## Runtime Lifecycle
 
 高层生命周期：
@@ -147,8 +166,14 @@ project_current_baseline_path:
 Execution Boundary Kernel（09）
 -> Planning Intent routing（07）
 -> Load .runtime/planning-layer-runtime Bootstrap Context（按需）
--> Discovery / Planning Conversation（00 + 07）
+-> Bind requirement_pool_path 与本期工作包路径
+-> 创建本期 current-interaction.yaml，保存初始需求与 discovery_checkpoint
 -> Project Current State Gate（07）
+-> 非第一次 Planning 读取 Requirement Pool 并执行相关性 / 冲突检查
+-> 检查项目本地证据，并对可公开核验、会影响下一问的事实执行联网调研
+-> 将最小调研结论、来源与时效写入 discovery_checkpoint
+-> Discovery / Planning Conversation（00 + 07）
+-> 每轮先持久化用户回答，再补充必要事实调研并更新 discovery_checkpoint，最后提出下一问题
 -> 确认目标、范围与成果用途
 -> 形成 execution_handoff_decision 候选
 -> 在本期 current-interaction.yaml 持久化最小恢复镜像与确认目标
@@ -214,6 +239,7 @@ Planning Document Mode 的逐文档生成前确认、生成后解释、用户确
 ## Document And Governance Boundaries
 
 - 文档生成必须遵循 `references/03-planning-doc-responsibility.md`、`references/04-planning-format-spec.md`、`references/05-planning-priority-system.md` 和 `references/06-planning-capability-governance.md` 定义的责任边界、格式、优先级、能力治理和门禁。
+- 跨期延期需求必须写入唯一 `<requirement_pool_path>`；00–15、Planning Context、15 下一期输入和 Handoff 只能在需要时引用 `POOL-ID`，不得复制形成第二份待处理需求正文。
 - 使用 `references/02-planning-change-levels.md`，由 Planning Runtime 内部评估变更影响范围，用于决定 Planning Conversation 的探索深度。
 - 涉及外部能力、SDK、OpenAPI、MCP、AI 提供方、基础设施依赖或人工能力时，按 `references/06-planning-capability-governance.md` 执行。
 - 实际装配 13 时，13 按 `references/10-planning-document-interaction-runtime.md` 完成确认后，14 和 15 作为执行记录框架与验收框架自动派生；它们只预置待填写事实位置，不填写任何实际执行、验证、验收、真实环境或发布结论。
@@ -240,7 +266,7 @@ Planning Document Mode 的逐文档生成前确认、生成后解释、用户确
 <phase_planning_runtime_directory>/
 ```
 
-其中 `current-interaction.yaml` 保存当前阶段、`execution_handoff_decision` 的最小恢复镜像、最小文档装配进度、当前交互和最近一条反馈，是上下文压缩与工具中断后的短期恢复来源；Planning Context 仍是执行交接分支的权威语义来源。所有期次级运行数据只能写入当前项目对应的本期目录，不得写入 Skill、`.runtime/planning-layer-runtime/`、项目根目录或其他期次目录。
+其中 `current-interaction.yaml` 从 Discovery 首轮开始保存逐轮 `discovery_checkpoint`、最小调研结论与来源、当前阶段、`execution_handoff_decision` 的最小恢复镜像、最小文档装配进度、当前交互和最近一条反馈，是上下文压缩与工具中断后的短期恢复来源；Planning Context 仍是执行交接分支的权威语义来源。所有期次级运行数据只能写入当前项目对应的本期目录，不得写入 Skill、`.runtime/planning-layer-runtime/`、项目根目录或其他期次目录。
 
 Project Runtime Evidence 只用于事件记录、决策记录和审计记录；默认不加载。
 

--- a/skills/planning-layer-runtime/agents/openai.yaml
+++ b/skills/planning-layer-runtime/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "规划层运行时"
-  short_description: "完成一期规划、文档审查、受控恢复、增量交接与发布后基线闭环"
-  default_prompt: "使用 $planning-layer-runtime 完成本期规划、文档审查或受控恢复，并对执行、测试中的变更先分类再做精确增量回流与交接。"
+  short_description: "先查事实并逐轮保存发现，维护需求池，完成规划与增量交接"
+  default_prompt: "使用 $planning-layer-runtime 在第一阶段先核实项目证据与可查公开事实，逐轮保存本期需求发现，核对并维护跨期需求池，完成规划文档、受控恢复，以及执行或测试变更的精确增量回流与交接。"

--- a/skills/planning-layer-runtime/references/00-planning-user-discovery.md
+++ b/skills/planning-layer-runtime/references/00-planning-user-discovery.md
@@ -7,6 +7,10 @@
 - User Discovery Runtime
 - User Discovery Interview
 - Adaptive Interview
+- Incremental Discovery Persistence
+- Discovery Fact Research
+- Functional Supplement Discovery
+- Requirement Pool Intake Support
 - Project Current State Discovery
 - Business Discovery
 - Business Translation
@@ -256,6 +260,8 @@ Planning Conversation Mode 的目标不是让用户填写问题表，
 ```text
 User Context Gate
 -> Project Current State Gate
+-> Requirement Pool Intake Gate（非第一次 Planning）
+-> Discovery Fact Research Gate
 -> Business Discovery
 ```
 
@@ -282,6 +288,8 @@ User Context Gate
 - 禁止把 1 到 3 个问题执行成固定三问模板。
 - 优先问最影响返工的点。
 - 已确认业务事实进入 Planning Context 来源区。
+- 每轮业务事实必须先进入本期 `current-interaction.yaml.discovery_checkpoint`，持久化成功后才允许提出下一问题。
+- 可以从项目证据或公开资料核验的客观事实必须先查证，不得把本可自行回答的问题转交给用户。
 
 禁止直接进入：
 
@@ -290,6 +298,99 @@ User Context Gate
 - 状态机
 - API 设计
 - 架构设计
+
+## 4.1 Incremental Discovery Persistence Gate
+
+Discovery 不得依赖“全部问题问完后再统一整理”。本 Gate 复用本期既有：
+
+```text
+<phase_planning_runtime_directory>/current-interaction.yaml
+```
+
+启动顺序：
+
+```text
+绑定本期工作包与 planning-runtime 路径
+-> 创建或恢复 current-interaction.yaml
+-> 将用户初始需求写入 discovery_checkpoint.initial_intake_summary
+-> 将当前关键未知项路由为 project_evidence / web_research / user_confirmation
+-> 完成会影响首问的本地证据检查与公开调研，并持久化 research_findings
+-> 持久化第一条 discovery_question 交互目标
+-> 再提出第一个实质性业务问题
+```
+
+每轮唯一顺序：
+
+```text
+收到用户回答
+-> 立即写入 latest_feedback，并绑定已持久化的 discovery_question
+-> 校验问题、轮次与回答绑定
+-> 把回答归一为 confirmed / candidate / superseded 事实和 unresolved_items
+-> 更新 discovery_checkpoint.revision、last_applied_round_id 与 active_question.answer_status
+-> 清除已经应用的 raw_user_input
+-> 回读校验本轮事实已落盘
+-> 对会影响下一问的可核验未知项执行本地证据检查或联网调研
+-> 将最小调研结论、来源、时效与规划相关性写入 discovery_checkpoint
+-> 回读校验调研结果已落盘
+-> 计算下一最大不确定项
+-> 先持久化下一条 discovery_question
+-> 再向用户提问
+```
+
+规则：
+
+- `discovery_checkpoint` 是正在形成的最小 Planning Context 检查点，不是正式业务 SoT，也不是完整聊天记录。
+- 已确认事实、仍为候选的理解、已被纠正的事实和未决项必须区分；不得把用户未确认的归纳写成 `confirmed`。
+- 用户纠正已有事实时，必须标记原事实 `superseded` 或以稳定引用说明被替代关系，不得静默覆盖后继续提问。
+- 一条用户回答包含多个有效业务事实时可以拆成多条结构化事实，但都必须引用同一 `source_round_id`。
+- 当前轮持久化或回读校验失败时停止提出下一问题，用业务白话报告无法安全保存当前进度；不得继续依赖聊天记忆推进。
+- 不记录 CoT、长篇推理、完整 AI 回复或已经应用后的完整用户原文。
+- 本期目录尚未合法绑定时，不得开始实质性 Business Discovery；先完成最小路径绑定，不得把运行状态写入 Skill、项目根目录、其他期次或 `.runtime/planning-layer-runtime/`。
+
+延期需求在本轮被用户确认后，必须按 `04-planning-format-spec.md` 立即写入 `<requirement_pool_path>`，并在 `discovery_checkpoint.relevant_requirement_pool_refs` 只保存 `POOL-ID`；不得只留在聊天、未决项或最终总结中。
+
+## 4.2 Discovery Fact Research Gate
+
+第一阶段先把未知项按事实来源分类，再决定是否问用户：
+
+```text
+项目本地可观察事实 -> 读取当前基线、正式文档、仓库、配置或已有证据
+公开可核验事实 -> 联网搜索并打开权威公开来源
+组织内部事实或业务决策 -> 向用户确认
+```
+
+以下情况只要会改变问题、范围、风险、可行性或验收口径，默认触发公开调研：
+
+- 用户提到具体产品、平台、提供方、SDK、API、库、协议、标准或基础设施能力。
+- 版本兼容、当前能力、限制、配额、价格、弃用状态、发布时间或时效性信息。
+- 法律、监管、行业规范、平台审核规则或安全要求。
+- 用户反馈中出现可以公开验证的能力判断、事实纠正或功能性补充。
+- AI 对技术约束或公开事实没有足够把握，且答案会影响下一问。
+
+来源优先级：
+
+```text
+项目当前基线与项目内权威证据
+-> 官方文档、官方公告、政府或标准组织等一手来源
+-> 论文、规范原文或其他权威来源
+-> 必要时用于交叉验证的可靠二手来源
+```
+
+规则：
+
+- 先保存当前用户反馈，再调研；不得为了搜索而延迟、覆盖或丢失本轮回答。
+- 首轮也必须在写入 `initial_intake_summary` 后、提出第一条实质性问题前完成必要调研。
+- 技术事实优先使用官方文档、规范或原始论文；法律与监管事实优先使用政府或监管机构来源；需要当前信息时记录版本、发布日期或检查时间。
+- 搜索查询只包含解决事实问题所需的最小公开信息。禁止把用户原话、未公开项目名、业务数据、账号、凭证、内部路径、内网地址、客户信息或其他敏感上下文发送到公开搜索。
+- 已由可靠证据核实的客观事实只能写入 `research_findings`，不得因为已核实就复制成 `facts`；不再要求用户回答同一事实。用户只需要确认内部事实、偏好、业务取舍和该事实是否适用于当前决策。
+- 用户确认某条调研结论适用于本期业务后，才允许生成对应业务 `fact`，并通过 `source_research_id` 引用原调研结论；`fact` 记录的是业务适用或取舍结论，不得复写公开资料正文。
+- 多个权威来源冲突、证据不足、页面不可访问或信息可能过期时，不得伪装成已核实；写入对应证据状态，只在其会阻塞规划时向用户说明或询问可提供的内部证据。
+- 调研是问题生成的前置输入，不是一次性研究报告。只保留能减少无效提问或改变规划判断的最小结论和来源，不保存网页全文、长引文、搜索过程或推理过程。
+- 搜索到的新功能、替代方案、限制补偿或最佳实践只作为 `candidate` 功能补充，不得静默变成本期范围。只有会实质改变目标、范围、风险或验收时，才用一个业务问题请用户判断。
+- 用户确认候选功能放到后续期次时，立即写入 Requirement Pool；确认纳入当前期时转为当前事实并进入 Planning Context；用户认为无关时标记为不适用，不反复追问。
+- 不为内部流程、未公开经营数据、组织偏好、责任归属或拍板决定进行公开搜索；这些内容只能来自项目权威证据或用户确认。
+
+当一次反馈包含多个可核验事实时，可以合并成一次小范围调研，但每条结论必须保留自己的 `research_id` 和来源。联网能力不可用时，把受影响项保持为 `unresolved_items`，`resolution_route: web_research`，不得改问用户去回忆公开资料，除非用户可以提供唯一内部来源。
 
 ## 发现输出（Discovery Output）
 
@@ -306,11 +407,19 @@ discovered_business_facts:
   pain_points:
   collaboration_roles:
   completion_rules:
+
+researched_facts:
+  - research_id:
+    finding_summary:
+    evidence_status:
+    sources: []
+    planning_relevance:
 ```
 
 规则：
 
-- 仅记录已确认业务事实。
+- `discovered_business_facts` 仅记录已确认业务事实；`researched_facts` 只记录有最小来源的客观调研结论。两者不得把同一句客观资料复制成双份事实。
+- 输出必须从已持久化的 `discovery_checkpoint` 汇总；不得从压缩后的聊天摘要重新猜测。
 - 不记录推理过程。
 - 不记录规划语言。
 - 不记录系统设计结论。
@@ -431,6 +540,12 @@ Planning Conversation Mode
 是否涉及数据库结构或破坏性变更
 是否有 UI 操作路径
 哪些内容明确不做
+每轮有效回答已写入 discovery_checkpoint
+会影响规划的项目内可核验事实已先检查
+会影响规划的公开可核验事实已调研，或已明确记录无法调研的阻断原因
+调研结论包含最小来源、检查时间和证据状态
+调研发现的功能补充未被静默扩为当前范围
+已确认延期需求已写入 Requirement Pool
 ```
 
 输出：
@@ -445,6 +560,8 @@ discovery_sufficiency:
 规则：
 
 - `decision` 只允许 `continue_interview` 或 `run_completion_gate`。
+- 检查点缺少最近已完成轮次、存在未应用反馈，或最新回答尚未落盘时，`decision` 必须为 `continue_interview`，且只能先恢复持久化事务，不能继续提问。
+- 存在 `resolution_route: project_evidence | web_research` 的关键未决项且尚未完成对应核验时，先执行调研，不得以用户提问替代；确实无法调研时保留阻断原因。
 - 关键项缺失时，不得进入正式文档生成。
 - 缺失时不得把完整 checklist 抛给用户。
 - 缺少身份、职位、协作位置或决策权判断时，先回到 User Context Discovery，不得直接追问业务建模问题。

--- a/skills/planning-layer-runtime/references/01-planning-core-rules.md
+++ b/skills/planning-layer-runtime/references/01-planning-core-rules.md
@@ -45,11 +45,13 @@
 - 当前前端体验基线只记录已经真实生效的体验事实和权威来源，不复制完整 CSS、Token、组件代码或设计资产；禁止新建第二份项目级设计基线文件。
 - 实际发布后，才允许依据 15 的发布事实更新生产当前状态与当前前端体验事实；已验收未发布仍只属于交付状态。
 - 一期关闭后，该期 00–15 进入历史只读；只允许受控修正事实错误，独立新增需求默认从最新 `PROJECT-CURRENT-BASELINE.md` 启动下一期。
+- 下一期除最新 `PROJECT-CURRENT-BASELINE.md` 外，还必须读取 `<requirement_pool_path>` 做相关性与冲突判断；池条目只能作为历史需求佐证，不能冒充已实现事实或自动成为本期范围。
 
 一期必须保持以下事实链，不得用最新完整文档覆盖历史执行事实：
 
 ```text
 当前项目事实
+-> Requirement Pool 中与本期输入相关的历史佐证
 -> 本期规划基线
 -> Planning Execution Baseline
 -> Change Set（仅冻结后发生变更时）
@@ -60,13 +62,14 @@
 
 ## 2.1 规划数据保存边界
 
-Planning 运行数据按职责只允许落在三个位置：
+Planning 相关数据按职责只允许落在四个位置：
 
 | 位置 | 只允许保存 | 禁止保存 |
 | --- | --- | --- |
 | `skills/planning-layer-runtime/` | 静态规则、路由、格式规范、职责说明、行为规则与必要 agents 配置 | 运行实例、运行文件复制源、项目、用户、环境、期次、反馈、进度、真实 Event / Decision / Audit 数据 |
 | `<phase_planning_runtime_directory>/` | 当前交互状态与本期 Event / Decision / Audit 证据 | 跨期用户画像、跨期环境档案、正式业务事实的替代副本 |
 | 项目根目录 `.runtime/planning-layer-runtime/` | 跨期稳定的用户交互倾向、项目与开发环境、启动入口 | 期次需求、业务事实、完整聊天、一次性情绪、凭证、运行日志 |
+| `<requirement_pool_path>` | 用户已确认延期、尚待后续期次判断的需求 | 当前项目事实、当前期正式范围、已消费需求、TASK、执行状态、聊天记录或正式 SoT 正文 |
 
 规则：
 
@@ -80,11 +83,13 @@ Planning 运行数据按职责只允许落在三个位置：
 - `.runtime/planning-layer-runtime/` 和期次 `planning-runtime/` 默认按本地私有数据处理；Skill 打包、分享或上传不得携带这两个项目目录。
 - 未得到用户明确要求时，用户倾向、电脑环境和用户原始反馈不得进入公开仓库；项目已有团队共享策略优先，确需共享时只允许共享脱敏后的稳定项目信息。
 - `.runtime/planning-layer-runtime/user-profile.yaml` 同时承载长期交互习惯和规划协作偏好，禁止新增第二个长期偏好文件。
-- 项目运行文件按需创建：进入该期 Planning Document Mode 时创建 `current-interaction.yaml`；Event、Decision、Audit 和各类 Summary 只在对应事件、快照、审计或压缩需求真实发生时创建；无内容文件不得为了目录完整性创建。
+- 项目运行文件按需创建：进入 `discovery_start` 且本期路径合法绑定后，必须在第一条实质性业务问题前创建 `current-interaction.yaml`；Event、Decision、Audit 和各类 Summary 只在对应事件、快照、审计或压缩需求真实发生时创建；无内容文件不得为了目录完整性创建。
 - `13-开发任务合同与落地清单.md` 是 Planning Execution Baseline 完整正文的唯一承载；首次 13 只读取已确认且适用的 01–12，确认后才在 13 中追加冻结基线区块。
 - 完整 Change Set 历史只作为追加式 Decision Snapshot 写入既有 `planning-runtime/decision-log.md`；它是范围准入与增量选择的 Runtime 证据，不是业务 SoT，不得复制完整 00–15 正文。
-- `current-interaction.yaml` 只保存 Planning Execution Baseline revision、当前 active Change revision、状态与 `decision_ref` 的最小恢复引用，不保存完整 Baseline、Change Set、TASK 或执行事实。
+- `current-interaction.yaml` 保存逐轮 Discovery 检查点，以及 Planning Execution Baseline revision、当前 active Change revision、状态与 `decision_ref` 的最小恢复引用；不保存完整聊天、完整 Baseline、Change Set、TASK 或执行事实。
 - 14、15 和 Handoff 只引用 Planning Execution Baseline revision、active Change Set revision 与必要 TASK contract revision，不重复定义其正文。
+- `<requirement_pool_path>` 是跨期待处理需求的唯一入口。已确认延期项必须立即写入；15 的下一期输入和 Handoff 只引用 `POOL-ID`，不得复制需求正文形成第二来源。
+- Requirement Pool 不是当前项目基线或正式业务 SoT。条目只有经新一期 Discovery 重新核对、确认纳入，并进入当前 Planning Context / 正式 SoT 后，才成为本期事实。
 
 ## 3. 最高优先级规则
 
@@ -99,6 +104,8 @@ Planning 运行数据按职责只允许落在三个位置：
 - 未确认内容不得写成事实。
 - 所有关键实体必须具备唯一 ID。
 - 所有关键结论必须可追踪到来源。
+- 可以从项目证据或公开权威资料核验的客观事实必须先查证；不得把公开事实、当前能力、版本限制或规范内容当作业务问题要求用户回忆。
+- 调研证据不能替代用户对内部事实、业务取舍、范围和适用性的确认；公开资料发现的新功能只作为候选，不得自动扩展本期范围。
 - 禁止多个文件定义同一事实。
 - 禁止混淆计划、验收、已开发未发布和已上线生产状态。
 - 状态流必须显式定义。
@@ -131,7 +138,7 @@ Planning 运行数据按职责只允许落在三个位置：
 以下 ID 及其包含的期次、阶段、版本或迭代标识，只用于 Planning 追踪：
 
 ```text
-REQ FLOW SCN DOMAIN MODULE STATE API PERM ARCH CAP TASK TEST RISK DEP OPEN EXEC
+REQ POOL FLOW SCN DOMAIN MODULE STATE API PERM ARCH CAP TASK TEST RISK DEP OPEN EXEC
 ```
 
 允许用途：
@@ -273,6 +280,7 @@ Project Current Baseline
 - 验收结果不能替代测试方案。
 - 执行记录不能替代任务清单。
 - Planning Execution Baseline 冻结后，Change Set 只能增量修订受影响合同，不得覆盖既有执行事实。
+- Requirement Pool 只参与新一期 Discovery 的输入核对，不得直接插入冻结后的执行队列或替代 Change Set 准入。
 - 14、15 中已经由后续阶段填写的事实不得被 Planning 删除、覆盖、重置或重新绑定。
 - 未受影响但尚未开始、仍属于原执行基线的 active TASK 必须继续承接，不得因为产生 Change Set 或替换旧 Handoff 而从执行队列丢失。
 
@@ -494,6 +502,8 @@ Planning Runtime 最终输出（仅以下四项）：
 3. assembled_documents
 4. handoff_role_mapping
 ```
+
+Requirement Pool 的创建、更新或消费删除属于 Planning 过程中的跨期输入维护，不增加第五种正式输出，也不替代上述四项。
 
 时机规则：
 

--- a/skills/planning-layer-runtime/references/02-planning-change-levels.md
+++ b/skills/planning-layer-runtime/references/02-planning-change-levels.md
@@ -164,10 +164,11 @@ replace_current_phase_scope
 规则：
 
 - 执行尚未开始且基线未冻结时，可以按影响范围修正规划，只重审受影响部分。
-- 执行已开始后，独立新增能力默认 `defer_to_next_phase`；15 已存在时写入其下一期输入区，15 尚不存在时写入 Planning Context 的 `future_phase_inputs`。
+- 执行已开始后，独立新增能力默认 `defer_to_next_phase`；用户确认延期后必须立即写入唯一 `<requirement_pool_path>`，不得等待 15、Handoff 或本期结束。
 - `defer_to_next_phase` 不改变当前执行基线，不创建本期 Change Set、不修改本期 TASK，也不重建当前 Handoff。
-- 后续实际派生 15 时，将已确认 `future_phase_inputs` 同步到 15；最终为 `planning_only` 时放入 planning_only Handoff，不得为了记录延期需求提前生成 13、14、15 或独立 Backlog。
-- 若 Planning Execution Baseline 已冻结而 14/15 尚未真实派生，该状态只能视为框架派生未完成的阻断中间态；可以继续在 Planning Context 记录 `future_phase_inputs`，但不得把 Change Set 推进到 `handoff_prepared`，也不得生成 `execution_ready` Handoff 或开始执行。
+- 后续实际派生 15 时，只在其“下一期输入”中引用 `<requirement_pool_path>#POOL-ID`；最终为 `planning_only` 时 Handoff 同样只引用池条目，不得复制需求正文，也不得为了记录延期需求提前生成 13、14、15。
+- 若 Planning Execution Baseline 已冻结而 14/15 尚未真实派生，该状态只能视为框架派生未完成的阻断中间态；可以写入 Requirement Pool，但不得把 Change Set 推进到 `handoff_prepared`，也不得生成 `execution_ready` Handoff 或开始执行。
+- Requirement Pool 写入成功不等于需求已进入下一期范围。下一期仍须按 `07-planning-conversation-runtime.md` 与用户当前输入比较并重新确认。
 - 新增内容确实阻断当前 P0 FLOW 且不纳入就无法达到本期验收目标时，优先评估 `absorb_as_current_phase_delta`；仍必须完成影响分析，不得因此扩大为整期重跑。
 - 必须留在本期且基线已冻结时，只能 `absorb_as_current_phase_delta` 并形成 Change Set。
 - 本期方向根本改变时才使用 `replace_current_phase_scope`，必须明确原任务保留、取消、替换和重新执行范围。

--- a/skills/planning-layer-runtime/references/03-planning-doc-responsibility.md
+++ b/skills/planning-layer-runtime/references/03-planning-doc-responsibility.md
@@ -52,7 +52,7 @@ planning handoff 给执行 skill 时，必须显式输出职责到路径的映�
 | 12 | 梳理 | 正式 RISK / DEP / OPEN 的唯一 SoT，归并 01–11 的风险信号、依赖和待决策事项 | 唯一正式 RISK-ID、DEP-ID、OPEN-ID，风险等级、影响范围、阻断阶段、处理策略、关闭条件、依赖验证来源、最晚解除阶段、OPEN 回写目标、确认主体、状态 | 01、02、03、04、05、06、07、08、09、10、11 | 13，以及 13 确认后派生的 14、15 | 已确认业务规则、状态、接口、权限、UI 事实、重复 RISK-ID、替上游关闭 OPEN |
 | 13 | 梳理 | 开发任务合同、当前有效 TASK 视图与冻结 Planning Execution Baseline 的唯一正文；冻结后只追加受影响 TASK revision | TASK-ID、task_revision、当前有效 TASK 视图、执行处置、前端绑定、Ready Gate、完成合同、Planning Execution Baseline 冻结区块 | 首次：已确认且适用的 01–12；增量：既有 Baseline、active Change Set、本次受影响 SoT、Recovery Output | 首次确认后派生 14/15；增量时只更新受影响框架与 Handoff | 首次生成依赖尚不存在的 Baseline、覆盖历史基线快照、把完整 13 当作全部执行队列、删除 TASK 历史或写实际结果 |
 | 14 | 派生框架 / 执行承载 | 由 planning skill 在 13 确认后派生并追加式维护的执行事实承载框架 | Planning Execution Baseline revision、TASK contract revision、active Change Set revision、允许执行范围、TASK 状态矩阵、EXEC、偏差/阻断/回写和测试交接位置 | 13、11、12、既有 14 真实事实 | 后续执行与测试承接方 | 重复定义 Baseline/Change Set 正文，覆盖/删除/重置真实事实，为未受影响 TASK 重建 EXEC，把旧事实绑定到新 TASK revision |
-| 15 | 派生框架 / 验收承载 | 验收、发布、复盘和下一期输入的事实承载框架；Planning 只维护未填写的受影响占位 | 验收基线、实际 TEST/CAP/RISK/DEP/发布事实区、PROJECT-CURRENT-BASELINE 更新条件与结果、复盘、deferred_improvement/下一期输入 | 11、12、13、14、既有 15 真实事实 | 后续验收承接方、发布后的 Project Current Baseline | 覆盖真实验收/发布事实、把框架状态冒充实际结果、提前更新生产基线 |
+| 15 | 派生框架 / 验收承载 | 验收、发布、复盘和下一期输入引用的事实承载框架；Planning 只维护未填写的受影响占位 | 验收基线、实际 TEST/CAP/RISK/DEP/发布事实区、PROJECT-CURRENT-BASELINE 更新条件与结果、复盘、Requirement Pool 引用 | 11、12、13、14、既有 15 真实事实 | 后续验收承接方、发布后的 Project Current Baseline | 覆盖真实验收/发布事实、复制延期需求正文形成第二来源、把框架状态冒充实际结果、提前更新生产基线 |
 
 ## 2.1 00/01/02 强化职责
 
@@ -790,7 +790,7 @@ planning skill 禁止预填：
 - 用户不需要单独确认 15。
 - 真实验收、发布和基线事实尚未填写。
 
-15 已存在真实 TEST、验收或发布事实时，Planning 只能追加或修订受影响且尚未填写的框架位置；不得删除、覆盖、回退或把旧事实错误绑定到新 TASK revision。允许延期且不阻断本期验收的 `deferred_improvement` 写入既有“下一期输入”。
+15 已存在真实 TEST、验收或发布事实时，Planning 只能追加或修订受影响且尚未填写的框架位置；不得删除、覆盖、回退或把旧事实错误绑定到新 TASK revision。允许延期且不阻断本期验收的 `deferred_improvement` 必须先写入 `<requirement_pool_path>`，15 的“下一期输入”只追加对应 `POOL-ID` 引用。
 
 ### 13 确认后的框架生成规则
 

--- a/skills/planning-layer-runtime/references/04-planning-format-spec.md
+++ b/skills/planning-layer-runtime/references/04-planning-format-spec.md
@@ -40,7 +40,7 @@
 
 按需创建规则：
 
-- `current-interaction.yaml`：`execution_handoff_decision` 第一次需要在发问前持久化时按需创建；不得等到进入 Planning Document Mode 后才创建，是唯一默认必需文件。
+- `current-interaction.yaml`：进入 `discovery_start` 且本期路径合法绑定后，在第一条实质性业务问题前创建；不得等到访谈结束、执行交接判断或 Planning Document Mode 才创建，是唯一默认必需文件。
 - `event-log.md`：第一次实际写入 Runtime Event 时创建。
 - `decision-log.md`：第一次实际存在 Decision Snapshot 时创建。
 - `audit-log.md`：真正触发 Runtime Audit 时创建；普通 Planning 不创建。
@@ -57,6 +57,14 @@
 .runtime/planning-layer-runtime/project-profile.yaml
 .runtime/planning-layer-runtime/context-index.yaml（仅在确有多个稳定上下文入口时）
 ```
+
+跨期待处理需求单独保存到：
+
+```text
+<requirement_pool_path>
+```
+
+默认绑定为 `<planning_root>/REQUIREMENT-POOL.md`，但项目已有等价文件时优先复用。Requirement Pool 是规划输入资产，不属于 `.runtime/planning-layer-runtime/`、期次 `planning-runtime/`、00–15 正文或执行 Backlog。
 
 其中：
 
@@ -109,6 +117,50 @@ last_updated:
 ```yaml
 current_phase:
 
+discovery_checkpoint:
+  status:
+  revision:
+  updated_at:
+  initial_intake_summary:
+  last_applied_round_id:
+  active_question:
+    question_id:
+    topic:
+    prompt_summary:
+    asked_at:
+    answer_status:
+  facts:
+    - fact_id:
+      topic:
+      summary:
+      confirmation_status:
+      source_round_id:
+      source_research_id:
+      supersedes_fact_id:
+  unresolved_items:
+    - item_id:
+      summary:
+      blocking:
+      resolution_route:
+      related_research_id:
+      next_question:
+  research_findings:
+    - research_id:
+      topic:
+      finding_summary:
+      evidence_scope:
+      evidence_status:
+      checked_at:
+      sources:
+        - source_type:
+          source_ref:
+          source_title:
+          source_version_or_date:
+      planning_relevance:
+      related_fact_ids: []
+      related_requirement_pool_refs: []
+  relevant_requirement_pool_refs: []
+
 execution_handoff_decision:
   requires_execution_handoff:
   handoff_type:
@@ -125,8 +177,6 @@ active_change:
   admission_result:
   change_status:
   decision_ref:
-
-future_phase_inputs: []
 
 document_assembly:
   planned_roles:
@@ -169,6 +219,7 @@ planning_status:
 
 ```text
 document
+discovery_question
 execution_handoff_decision
 final_summary
 scope_change_decision
@@ -178,6 +229,7 @@ scope_change_decision
 
 ```text
 pre_generation_confirmation
+discovery_answer
 draft_confirmation
 execution_handoff_confirmation
 final_summary_confirmation
@@ -219,6 +271,20 @@ planning_handoff_complete
 
 规则：
 
+- `discovery_checkpoint.status` 只允许 `in_progress`、`ready_for_completion_gate`、`compiled_into_planning_context`；`revision` 每成功应用一轮回答后单调递增。
+- Discovery Runtime ID 在本期内唯一且单调递增：问题使用 `DQ-<SEQ>`，回答轮次使用 `DR-<SEQ>`，结构化事实使用 `DF-<SEQ>`，未决项使用 `DU-<SEQ>`，调研结论使用 `RF-<SEQ>`；这些 ID 只属于 `current-interaction.yaml`，不得进入正式实现命名。
+- `active_question.answer_status` 只允许 `awaiting_answer`、`recorded`、`applied`、`superseded`；一条问题在 `awaiting_answer` 前必须已持久化 `question_id / topic / prompt_summary / asked_at`。
+- `facts[].confirmation_status` 只允许 `candidate`、`confirmed`、`superseded`。用户纠正事实时不得静默覆盖；旧事实标记 `superseded`，新事实使用新 `fact_id` 并填写 `supersedes_fact_id`。
+- `facts` 只保存用户表达、项目当前基线以及用户确认后的业务适用或取舍结论。公开或项目证据核实出的客观资料只进入 `research_findings`，不得直接复制进 `facts`。当用户确认某条调研结论适用于本期业务时，新业务事实填写 `source_research_id: <RF-ID>`；没有调研来源时省略该字段。
+- `unresolved_items[].resolution_route` 只允许 `project_evidence`、`web_research`、`user_confirmation`；可自行核验的项不得错误路由成 `user_confirmation`。关联既有调研时填写 `related_research_id`，否则留空或省略。
+- `research_findings[].evidence_scope` 只允许 `project_local`、`external_public`；`evidence_status` 只允许 `verified`、`conflicting`、`insufficient`、`stale`；`planning_relevance` 只允许 `evidence_only`、`candidate`、`confirmed_applicable`、`not_applicable`。
+- 每条 `research_findings` 只保存影响当前规划判断的最小结论与来源定位。项目内来源使用真实文件路径或稳定证据 ID；公开来源使用可追溯 URL，并在可得时记录版本或发布日期。禁止保存网页全文、长引文、搜索结果页、搜索词历史、用户敏感信息或 AI 推理。
+- `verified` 只表示来源足以支持客观结论，不等于用户已确认其业务适用性；会改变范围、取舍或验收的结论必须保持 `candidate`，直到用户确认后才转入对应业务事实或 Requirement Pool。
+- 调研发现的延期功能正文只进入 Requirement Pool；`research_findings.related_requirement_pool_refs` 与 `relevant_requirement_pool_refs` 只保存 `POOL-ID`。调研结论不得成为第二份延期需求正文。
+- 用户初始需求必须在第一条实质性业务问题前写入 `initial_intake_summary`；这里只保存结构化短摘要，不保存整段聊天。
+- 收到 Discovery 回答后，必须先把 `latest_feedback` 绑定到当时已持久化的 `discovery_question` 并写为 `recorded`，再更新事实与未决项。完成应用后清除 `raw_user_input`，更新 `last_applied_round_id`，回读校验成功后才允许写入下一条问题。
+- `discovery_checkpoint` 是当前期未完成 Planning Context 的最小恢复检查点，不是正式 SoT、Decision Log、完整 Planning Context 副本、访谈历史或研究报告。只保留会改变规划方向、范围、授权、流程或验收的事实、未决项与最小调研结论。
+- 已确认延期需求的正文只进入 `<requirement_pool_path>`；`relevant_requirement_pool_refs` 只记录 `POOL-ID`，不得复制需求池正文。
 - `execution_handoff_decision` 只保存恢复分支所需的最小镜像：`requires_execution_handoff` 只允许 `true | false`，`handoff_type` 只允许 `execution_ready | planning_only`，`decision_status` 只允许 `candidate | confirmed`；`decision_basis` 只写存在或不存在后续工程任务的原因，`decision_source` 只允许实际使用的 `user_confirmation`、`confirmed_planning_context`、`document_assembly_requirement`。
 - Planning Conversation 中已确认的 Planning Context 是 `execution_handoff_decision` 的权威语义来源；本文件只是短期恢复镜像，不是第二套 Planning Context、业务 SoT、完整对话或推理记录。
 - `document_assembly.planned_roles` 只记录本期计划装配的职责，不预造文件路径；`generated_documents` 只加入已经真实生成的本期文档及其 `role / path / status`，路径必须真实存在；不得复制正式文档正文、完整 `assembled_documents` 或 Handoff Package。
@@ -226,8 +292,9 @@ planning_handoff_complete
 - `planning_execution_baseline_reference` 只在执行基线冻结后保存 `phase_id / revision` 的最小恢复引用；完整 Baseline 正文只存在于 13。
 - `active_change` 只保存当前 `change_revision / admission_result / change_status / decision_ref`；`decision_ref` 必须使用 `<phase_planning_runtime_directory>/decision-log.md#decision_id=<DEC-ID>` 精确指向本期既有 Change Set Decision Snapshot。该 Snapshot 同时承载完整 Change Set 与按 08 格式生成的 Recovery Output；不得在 `current-interaction.yaml` 复制它们、Baseline、TASK 或执行事实。
 - `change_status` 只允许 `candidate`、`confirmed`、`applied_to_planning`、`handoff_prepared`、`closed`、`superseded`。新变化到达时不得直接覆盖尚未关闭的 `active_change`。
-- `future_phase_inputs` 只是在 15 尚不存在时对已确认 Planning Context 同名字段的最小恢复镜像，条目格式复用本文件后述唯一格式；它不是第二个 Planning Context。同步到 15 或 planning_only Handoff 后，以正式承载为准，并清空已转移正文或只保留同步状态。
 - 每一期只使用本期 `<phase_planning_runtime_directory>/current-interaction.yaml`；不得跨期共用或覆盖，不得把本期状态写入 Skill、`.runtime/planning-layer-runtime/`、项目根目录或其他期次目录。
+- 第一期和后续任意期次都必须逐轮写 Discovery 检查点；“这是第一次执行”不得成为延迟持久化的理由。
+- Discovery 发问前的唯一绑定格式为 `target_type: discovery_question`、`target_id: <DQ-ID>`、`stage: discovery_answer`、`version: <当前 checkpoint revision>`；`latest_feedback.target_id` 必须复制同一 `DQ-ID`。
 - 向用户发出任何会影响流程状态的确认问题前，必须先写完整 `active_interaction`；不得等用户回复后再从聊天记忆推断确认对象。
 - 文档确认时，`target_id` 使用真实文档路径。
 - 执行交接分支确认固定使用 `target_type: execution_handoff_decision`、`target_id: current_phase_execution_handoff_decision`、`stage: execution_handoff_confirmation`；必须先写入候选镜像和该交互目标，再向用户发问。
@@ -239,7 +306,80 @@ planning_handoff_complete
 - 同一反馈不得同时确认当前目标并消费下一目标。
 - Planning 真正完成后清空待处理反馈，并将 `planning_status` 设为 `planning_handoff_complete`。
 
-### 1.3 Planning Execution Baseline / Change Format
+### 1.3 Requirement Pool Format
+
+跨期待处理需求的唯一文件：
+
+```text
+<requirement_pool_path>
+```
+
+文件存在时，每个条目使用：
+
+```markdown
+# Requirement Pool
+
+本文档只保存用户已确认延期、尚待后续期次判断的需求。它不是项目当前事实、当前期范围、正式业务 SoT、TASK 或执行 Backlog。
+
+### POOL-<DOMAIN>-<SEQ>：<需求短标题>
+
+需求摘要：
+
+预期业务价值：
+
+语义比较键：
+- 涉及角色：
+- 涉及业务对象：
+- 涉及流程或场景：
+- 预期结果：
+- 硬约束：
+
+来源期次或工作包：
+
+来源类型：
+- discovery_deferred / scope_admission_deferred / acceptance_deferred
+
+延期原因：
+
+关联当前期 ID：
+
+首次确认时间：
+
+最近更新时间：
+
+最近确认来源：
+```
+
+文件与条目规则：
+
+- 文件不存在且没有真实延期需求时视为空池，不预建空文件；第一次确认延期后创建。
+- Requirement Pool 只保留尚未被当前期正式消费的条目，因此不使用 `done`、`closed`、`consumed` 等历史状态堆积已完成项。
+- `POOL-ID` 在项目规划根目录内稳定唯一。条目按需求语义去重；同一角色、业务对象、流程目标与硬约束指向同一件事时更新既有条目，不新增同义条目。
+- 只有用户已确认延期的需求才能写入。候选想法、AI 推测、当前期未决问题、已纳入当前期范围的需求、TASK、Bug、执行状态和完整聊天不得进入。
+- 延期决定确认后必须在继续下一轮提问、生成文档、准备 Handoff 或输出总结前写入并回读校验；不得等待本期结束时批量补记。
+- 15“下一期输入”和 Handoff 只引用 `<requirement_pool_path>#POOL-ID`，不得复制需求正文或维护第二份状态。
+
+非第一次 Planning 的语义比较只允许三种结果：
+
+```text
+same
+conflict
+unrelated
+```
+
+- `same`：主动提醒用户这是历史已确认延期需求，并把 `POOL-ID` 作为 Discovery 来源佐证；用户确认纳入当前期且对应事实已进入当前 Planning Context 后，删除该完整条目。
+- `conflict`：在继续范围探索前向用户说明池中旧需求、当前新表达和冲突影响；用户确认最新方向后，先原位更新该 `POOL-ID` 的需求摘要、比较键、来源与最近更新时间，不创建重复条目。仅在更新后的需求随后被当前 Planning Context 正式纳入时删除。
+- `unrelated`：不向用户展示，不影响当前探索，不更新、不删除，留待后续期次。
+
+消费和修改规则：
+
+- 正常消费必须删除整个已纳入条目，禁止保留“已完成需求墓地”。
+- 冲突处理必须先更新为用户最新确认需求；不得保留旧需求正文作为并列候选，也不得静默以当前输入覆盖。
+- 删除或更新前必须核对 `POOL-ID`、当前用户确认与当前 Planning Context 归属。未确认纳入时不得删除。
+- 同一次写入只修改命中的条目；不得重排、重写或清理无关需求。
+- 文件更新失败时停止消费、延期或下一轮 Planning 推进，不得只靠聊天记忆继续。
+
+### 1.4 Planning Execution Baseline / Change Format
 
 Planning Execution Baseline 完整正文的唯一承载是：
 
@@ -328,21 +468,7 @@ change_set:
 
 Change Set 与 `active_change.change_status` 共用同一状态枚举：`candidate`、`confirmed`、`applied_to_planning`、`handoff_prepared`、`closed`、`superseded`。
 
-15 尚不存在时，延期需求暂由已确认 Planning Context 承载：
-
-```yaml
-future_phase_inputs:
-  - source:
-    summary:
-    defer_reason:
-    related_current_phase_ids: []
-    expected_next_phase_value:
-    status:
-```
-
-`status` 只允许 `candidate`、`confirmed`、`transferred_to_15`、`handed_off`。15 后续真实派生时，把已确认项同步到 15 下一期输入区并标记 `transferred_to_15`；最终为 planning_only 时写入其 Handoff 并标记 `handed_off`，不得为此提前生成 13、14、15 或独立 Backlog。
-
-在 15 尚不存在期间，Planning Context 是上述内容的临时权威来源，`current-interaction.yaml.future_phase_inputs` 只做中断恢复镜像。若 Baseline 已冻结但 14/15 尚未真实派生，视为框架派生未完成：不得生成 `execution_ready` Handoff，也不得把 active Change Set 标记为 `handoff_prepared`。
+延期需求无论 15 是否存在，都立即进入唯一 `<requirement_pool_path>`。15 的“下一期输入”、planning_only Handoff 或 execution_ready Handoff 只记录本期产生或引用的 `POOL-ID` 与真实路径，不复制条目正文。不得为记录延期需求提前生成 13、14、15。
 
 ## 2. 一级标题
 
@@ -372,6 +498,7 @@ future_phase_inputs:
 
 ```text
 REQ-xxx
+POOL-xxx
 FLOW-xxx
 SCN-xxx
 DOMAIN-xxx
@@ -404,6 +531,7 @@ TEST-xxx
 - 不允许同义重复
 - 不允许自然语言替代
 - 本节 ID 全部是 `trace_only`，只用于 Planning 文档、执行/验收记录和变更证据追踪；不得转换为长期代码、数据库、API、权限、配置、迁移或测试套件命名。
+- `POOL-ID` 只用于跨期待处理需求引用，不得直接成为 REQ、TASK 或实现命名；需求纳入当前期后仍须生成本期自己的 `REQ-ID`，再删除已消费池条目。
 - ID 中的期次、阶段、Sprint 或版本标识不代表物理技术域；完整边界以 `01-planning-core-rules.md#32-planning-trace-id-boundary` 为唯一来源。
 - PROMPT 必须关联适用的 PAGE、UI-MOD 或 UX-SCN；PROMPT-STYLE 必须关联适用页面、模块或 UX 范围。
 - ASSET 在 `received`、`review_pending`、`visual_confirmed` 或 `superseded` 状态下必须关联实际收到的图或明确的外部引用。
@@ -2392,7 +2520,7 @@ Task Completion Contract 必须明确：
 8. 发布判定与发布事实区
 9. PROJECT-CURRENT-BASELINE 更新条件与结果区
 10. 复盘
-11. 下一期输入
+11. 下一期输入（只引用 Requirement Pool）
 ```
 
 文档必须包含：
@@ -2452,6 +2580,7 @@ planning skill 只允许预填：
 - 15 不得因框架生成写入通过、失败、已验收、真实环境已通过、可发布、已发布、生产已更新或 PROJECT-CURRENT-BASELINE 已更新。
 - 已有实际 TEST、CAP、验收、发布或基线更新事实时不得覆盖、删除或回退；Change Set 只允许追加受影响验收项或修订尚未填写的占位。
 - 实际发布确认后，15 才记录 PROJECT-CURRENT-BASELINE 更新结果；Planning 框架生成不能执行该更新。
+- 下一期输入只允许列出 `<requirement_pool_path>#POOL-ID` 和一句引用目的；需求正文、延期状态和消费状态只在 Requirement Pool 维护。
 
 ### 12/13/14/15 State Separation Rule
 

--- a/skills/planning-layer-runtime/references/05-planning-priority-system.md
+++ b/skills/planning-layer-runtime/references/05-planning-priority-system.md
@@ -75,7 +75,7 @@ Priority 使用 `P0/P1/P2`。
 - 不影响核心业务闭环
 - 不影响上线门禁
 - 不影响安全、权限、数据正确性或关键验收
-- 可进入 backlog
+- 可进入 Requirement Pool
 
 是否阻塞上线：否
 
@@ -135,13 +135,13 @@ Priority 不等于 Severity。
 - 已完成的 P1 必须有下游验证结果
 - 未完成的 P1 必须记录延期原因
 - 未完成的 P1 必须确认不阻塞上线
-- 未完成的 P1 必须进入后续任务或 backlog
+- 未完成的 P1 必须进入后续任务；经用户确认延期时进入 Requirement Pool
 
 ### P2 Gate
 
 上线前允许延期：
 
-- P2 可进入 backlog
+- P2 可进入 Requirement Pool
 - P2 不得阻塞 P0
 - P2 不得伪装为 P1/P0
 - P2 延期必须保留来源和处理建议
@@ -165,13 +165,14 @@ Priority 不等于 Severity。
 
 - P0 必须全部通过或由 release gate 明确阻断。
 - P1 允许有限遗留。
-- P2 可进入 backlog。
+- P2 可进入 Requirement Pool。
 
 规则：
 
 - P0 验证失败时不得进入上线通过结论。
 - P1 遗留必须说明影响范围、延期原因和后续处理位置。
 - P2 遗留必须保留可追踪来源。
+- 任何延期进入 Requirement Pool 的 P1/P2 都必须使用 `<requirement_pool_path>#POOL-ID`；不得在 15 或 Handoff 复制形成第二份 backlog。
 - 验收结果必须按 Priority 汇总。
 - planning-layer-runtime 不记录测试执行状态或测试结果。
 

--- a/skills/planning-layer-runtime/references/07-planning-conversation-runtime.md
+++ b/skills/planning-layer-runtime/references/07-planning-conversation-runtime.md
@@ -14,6 +14,7 @@ Planning Layer Runtime 支持两种模式：
 - 用户以自然语言启动规划时，默认进入 Planning Conversation Mode。
 - Planning Context 完整后，才允许进入 Planning Document Mode。
 - 用户直接要求生成文档但上下文不完整时，先进入 Planning Conversation Mode。
+- `discovery_start` 必须在第一条实质性业务问题前创建或恢复本期 `current-interaction.yaml`，先核实会影响首问的项目与公开事实，并逐轮持久化 Discovery；禁止等所有问题结束后统一补记。
 
 ### 1.1 Planning Intent Subtype and Planning Exploration Guard
 
@@ -210,7 +211,9 @@ Planning Conversation Mode 启动前，按需读取 `.runtime/planning-layer-run
 
 ```text
 User Context Gate（读取 / 复用 / 自然识别；不阻塞业务探索）
-→ Project Current State Gate + Business Discovery（按当前最大不确定性并行推进）
+→ Project Current State Gate + Requirement Pool Intake Gate（非第一次 Planning）
+→ Discovery Fact Research Gate
+→ Business Discovery（按当前最大不确定性推进）
 → Planning Conversation
 → Discovery Sufficiency Gate
 → Planning Completion Gate
@@ -259,6 +262,49 @@ current_frontend_experience_baseline_available_or_not_applicable
 - 不得用已有旧代码绕过业务规划结论。
 - 不得新建独立设计基线文件；当前前端体验事实只进入唯一 `PROJECT-CURRENT-BASELINE.md`。
 
+### 2.4 Requirement Pool Intake Gate
+
+非第一次 Planning 启动时，在进入范围收敛前必须读取：
+
+```text
+<requirement_pool_path>
+```
+
+文件不存在时按空池处理；不得为此创建空文件。读取遵守最小上下文原则：先读取条目标题和语义比较键，只展开与用户当前输入可能相关的条目。
+
+比较维度：
+
+```text
+涉及角色
+业务对象
+流程或场景
+预期业务结果
+硬约束
+```
+
+比较结果只允许：
+
+```text
+same
+conflict
+unrelated
+```
+
+处理规则：
+
+- `same`：在第一阶段自然提醒用户“这个需求之前已暂存”，说明对应历史需求和当前表达为何是同一件事，并把 `POOL-ID` 作为 Discovery 来源佐证；不得直接当作本期已确认范围。用户确认本期纳入且事实已进入当前 Planning Context 后，删除该池条目。
+- `conflict`：暂停受影响范围的推进，用业务白话并列说明旧需求、当前表达和会造成的流程/角色/结果冲突，只问一个决策问题。用户确认最新方向后，先原位更新同一 `POOL-ID` 为最新需求，再继续 Discovery；不得同时保留两条冲突需求。更新后的需求只有正式纳入当前 Planning Context 后才删除。
+- `unrelated`：保持条目不变，不向用户展示，不把它强行拉入当前期；留待后续期次。
+
+规则：
+
+- 语义相同不得只按关键词判断；任一关键硬约束相反时至少为 `conflict`。
+- Requirement Pool 是历史需求佐证，不是当前项目事实。它不得覆盖 Project Current Baseline，也不得绕过用户当前确认。
+- 同一当前需求最多命中一个语义主条目；存在多个重叠池条目时先在池内去重，再向用户说明。
+- 比较结果和引用写入 `discovery_checkpoint.relevant_requirement_pool_refs`；需求正文不复制到 `current-interaction.yaml`。
+- 池条目的新增、更新、删除必须在继续下一轮提问前写入并回读校验。失败时停止推进，不得靠聊天记忆假装已维护。
+- 第一次 Planning 也允许在讨论中把已确认延期需求写入 Requirement Pool；“非第一次”只决定启动时是否存在需要读取的历史条目。
+
 ## 3. 对话生命周期（Conversation Lifecycle）
 
 ### 3.1 对话阶段（Layer 1 可见）
@@ -266,7 +312,8 @@ current_frontend_experience_baseline_available_or_not_applicable
 默认阶段：
 
 ```text
-探索定位（自然理解、关键未知、一个推进问题）
+Discovery 检查点建立与 Requirement Pool 核对
+→ 探索定位（自然理解、关键未知、一个推进问题）
 → 当前状态确认
 → 目标确认
 → 范围确认
@@ -313,6 +360,56 @@ current_frontend_experience_baseline_available_or_not_applicable
 - Discovery Sufficiency Gate 通过前，不得进入 Planning Document Mode。
 - User Discovery Runtime 必须读取或检查 User Context Gate；若用户输入已包含明确业务目标或业务问题，不得等待 User Context Gate 字段补齐后才开始业务发现。
 
+#### 3.2.1 Discovery Round Transaction
+
+本节是 Planning Conversation Mode 中逐轮发现事务的唯一行为规则，字段格式以 `04-planning-format-spec.md` 为准。
+
+首次启动：
+
+```text
+解析 planning_root、phase_planning_directory 与 phase_planning_runtime_directory
+-> 创建或恢复 current-interaction.yaml
+-> 写入 initial_intake_summary
+-> 非第一次 Planning 执行 Requirement Pool Intake Gate
+-> 将未知项路由为 project_evidence / web_research / user_confirmation
+-> 检查会影响首问的本地证据和公开权威来源，并持久化 research_findings
+-> 写入第一条 active_interaction: discovery_question
+-> 再输出第一个实质性业务问题
+```
+
+用户每次回答后的唯一顺序：
+
+```text
+收到输入
+-> 在做下一步规划判断前写入 latest_feedback: recorded
+-> 绑定当前 discovery_question / question_id / checkpoint revision
+-> 校验并分类回答
+-> 更新 facts / unresolved_items / relevant_requirement_pool_refs
+-> 若确认延期，立即写入 Requirement Pool
+-> feedback applied，清除 raw_user_input
+-> discovery_checkpoint revision + 1
+-> 回读验证
+-> 对会影响下一问的 project_evidence / web_research 未决项执行核验
+-> 持久化 research_findings 并再次回读验证
+-> 选择下一个最大不确定项
+-> 持久化下一条 discovery_question
+-> 再回复用户
+```
+
+强规则：
+
+- 不允许连续问多轮后再批量写入。
+- 不允许先回复下一问题，再异步补记上一轮。
+- 不允许只保存“问到第几题”；必须保存足以恢复规划判断的结构化事实和未决项。
+- 可以自行核验的客观事实必须先按 `00-planning-user-discovery.md#42-discovery-fact-research-gate` 调研；只有内部事实、业务取舍、适用性或无法由证据解决的阻断项才形成用户问题。
+- 已核验的项目或公开资料只写 `research_findings`；不得混入 `facts` 冒充用户确认。用户确认业务适用性后生成的业务事实必须引用对应 `RF-ID`。
+- 调研发现的功能补充先保持候选；未经用户确认不得进入当前范围，确认延期时必须先写入 Requirement Pool。
+- 用户说“暂停”“稍后继续”时，也必须先应用当前回答并保存检查点，再结束本轮。
+- 写入或回读失败时不得继续提问、进入 Completion Gate 或生成文档。
+- 如果本期目录无法合法确定，只允许先完成路径绑定；不得开始会产生业务事实的实质性 Discovery。
+- 路径绑定只建立本期工作包的恢复位置，不等于命名第 X 期、定义期次主题或提前收口范围；Planning Exploration Guard 仍然生效。
+- Planning Context 完成后，把检查点标记为 `compiled_into_planning_context`；不得删除仍用于本期中断恢复的结构化事实。
+
 ### 3.3 Discovery Priority Rule
 
 Discovery 阶段的目标不是快速补齐 Planning Context 字段，而是优先理解用户当前表达中的最大业务不确定性。
@@ -324,6 +421,7 @@ Discovery 阶段的目标不是快速补齐 Planning Context 字段，而是优�
 当前业务目标
 当前阻塞点
 当前影响规划方向的不确定因素
+项目证据与公开调研仍无法解决的业务未知
 ```
 
 规则：
@@ -331,6 +429,7 @@ Discovery 阶段的目标不是快速补齐 Planning Context 字段，而是优�
 - 不得为了填充 Planning Context 模板主动遍历所有字段。
 - 不得连续询问角色、权限、数据、状态、模块、页面、接口等字段清单。
 - 只有某个缺失信息会改变规划方向、范围、授权边界或验收结果时，才主动追问。
+- `resolution_route: project_evidence | web_research` 的项先查证，不得直接追问用户；调研完成后只问剩余的内部决策或适用性问题。
 - 当用户已经给出业务问题时，首轮问题应围绕真实流程、当前卡点或结果影响，而不是身份标签或专业字段。
 - 每轮只问当前最能改变下一步判断的一个自然问题。
 
@@ -381,9 +480,15 @@ Planning Conversation Runtime 开始前必须优先读取：
 ```yaml
 user_profile
 discovered_business_facts
+discovery_checkpoint
+research_findings
 ```
 
 若事实已确认，禁止重复提问。
+
+恢复或继续对话时，以本期已持久化 `discovery_checkpoint` 为当前 Discovery 事实来源；压缩摘要只可辅助定位，不得覆盖检查点。
+
+已持久化且仍在时效范围内的 `verified` 调研结论允许复用；存在 `stale`、`conflicting`、`insufficient` 或版本/规则可能已变化时先重新核验，不得重复询问用户公开事实。
 
 仅允许：
 
@@ -424,6 +529,9 @@ discovered_business_facts
 
 ### 4.3 输出规则
 
+- 用户可见回复前必须完成本轮 Discovery Round Transaction；尚未落盘的回答不得只存在于即将发送的自然语言理解中。
+- 用户可见回复中的“自然理解”和“当前未知”必须可追溯到当前 `discovery_checkpoint`；不得与已持久化事实冲突。
+- 若回复包含下一问题，必须先将该问题写为 `active_interaction.target_type: discovery_question`、`stage: discovery_answer`，再输出问题。
 - 内部轮次状态仅用于日志、恢复、上下文管理。
 - 用户可见回复才是给用户看的内容。
 - 用户态回复必须像正常协作对话。
@@ -735,7 +843,8 @@ UI/交互：
 风险：
 验收：
 待确认项：
-future_phase_inputs:
+调研事实与来源：
+Requirement Pool 相关引用：
 涉及文档：
 执行交接判断：
   execution_handoff_decision:
@@ -754,7 +863,9 @@ future_phase_inputs:
 - 当前项目状态必须区分生产当前、已开发未发布、已验收未发布和计划目标。
 - 涉及 UI 时，当前前端体验基线必须引用 `PROJECT-CURRENT-BASELINE.md` 的当前事实和权威来源，不复制设计资产。
 - FLOW 只记录 Planning Conversation 已确认或待确认的业务旅程，不替代 01 的正式 Flow Contract。
-- 15 尚不存在时，已确认的延期输入暂由 `future_phase_inputs` 承载；后续派生 15 时同步到其下一期输入区，planning_only 时进入 Handoff。不得为记录延期项提前生成 13、14、15。
+- 已确认延期需求必须立即写入 `<requirement_pool_path>`；Planning Context 只保存与本期讨论有关的 `<requirement_pool_path>#POOL-ID` 引用，不复制需求正文。不得为记录延期项提前生成 13、14、15。
+- Planning Context 必须从 `discovery_checkpoint` 汇总；最近一轮回答未落盘、存在未应用反馈或检查点无法回读时不得标记 COMPLETE。
+- Planning Context 只纳入与本期结论有关的最小调研事实、来源、版本或检查时间；不得复制网页正文、搜索过程或未经确认的功能候选。客观证据可支持事实，业务适用性与范围仍须按 Discovery 规则确认。
 - `execution_handoff_decision` 属于现有 Planning Context，不新增第二套 Planning Context、Runtime 文件、日志或状态机。
 - `requires_execution_handoff` 只允许 `true` 或 `false`；`handoff_type` 必须分别对应 `execution_ready` 或 `planning_only`。
 - `decision_source` 只记录实际来源：`user_confirmation`、`confirmed_planning_context`、`document_assembly_requirement`；可按实际情况记录一项或多项。
@@ -779,6 +890,8 @@ Planning Context 标记 `COMPLETE` 前，必须先完成以下唯一顺序：
 
 ```text
 Planning Conversation 已确认目标、范围与成果用途
+-> discovery_checkpoint 的全部反馈已应用并通过回读校验
+-> 从检查点汇总 Planning Context，并标记 compiled_into_planning_context
 -> 形成 execution_handoff_decision 候选
 -> 写入本期 current-interaction.yaml 最小恢复镜像
 -> 持久化 execution_handoff_confirmation 交互目标
@@ -910,7 +1023,7 @@ Planning Context COMPLETE
 - 不生成 13、14、15。
 - 不运行 Task Contract Gate、Implementation Naming Gate、Implementation Contract Completeness Gate 或 Execution and Acceptance Framework Derivation Gate。
 - Handoff 不包含 `Development Landing Checklist`、`Execution and Integration Record`、`Acceptance and Retrospective Record`，也不包含针对代码执行的 `execution_constraints`。
-- Planning Context 存在已确认 `future_phase_inputs` 时，Handoff 必须保留这些输入并标记 `handed_off`；不得为此生成 13、14、15。
+- 本期产生延期需求时，Handoff 只保留 `<requirement_pool_path>#POOL-ID` 引用；不得复制需求正文或为此生成 13、14、15。
 - 如果本期结论需要交给开发执行，即使变更很小，也必须改走分支 A。
 
 用途：
@@ -925,7 +1038,9 @@ Handoff Package 格式：
 ```yaml
 handoff_type: <planning_only | execution_ready>
 requires_execution_handoff: <true | false>
-future_phase_inputs: []
+deferred_requirement_refs:
+  requirement_pool_path: <本期存在延期项时填写真实路径>
+  pool_ids: []
 
 # Handoff Package 的完整结构、分支条件和生成规则由本节维护
 # frontend_experience_binding 等复用子格式以 04-planning-format-spec.md 为唯一格式来源
@@ -1030,6 +1145,7 @@ Handoff.active_change_revision
 - 必须来自本次 Planning Runtime 的正式输出。
 - 上述 YAML 只表达允许的职责名；实际 Handoff 只能列出本期真实已生成且适用的 role。
 - Handoff 不得包含尚未生成的文档、空占位路径、假设路径或未适用职责。
+- `deferred_requirement_refs` 只在本期新增或引用延期项时出现，只包含真实 `<requirement_pool_path>` 与 `POOL-ID`；不得复制需求摘要、状态或消费规则。
 - `handoff_type: execution_ready` 必须具备 13、14、15、Planning Execution Baseline revision、`execution_constraints` 与 `incremental_execution_contract`，且 Task Contract Gate、Implementation Naming Gate、Implementation Contract Completeness Gate 与 Execution and Acceptance Framework Derivation Gate 均已通过。
 - 首次 `execution_ready` 在顶层与 `incremental_execution_contract` 内同时省略 `active_change_revision`；增量 `execution_ready` 两处必须包含完全一致的合法 active Change Set revision，并与 `current-interaction.yaml.active_change.change_revision` 及 `decision_ref` 指向的 Change Set revision 一致。任何分支都不得生成空键或伪造 revision。
 - `handoff_type: planning_only` 禁止包含 Development Landing Checklist、Execution and Integration Record、Acceptance and Retrospective Record、`planning_baseline_revision`、`active_change_revision`、`execution_constraints` 与 `incremental_execution_contract`；允许包含本期实际生成的 Requirement and Scope、Business Domain、UI/UX Design、Architecture Decision、Capability Governance、Test and Acceptance Plan、Risk, Dependency, and Open Questions 等职责。
@@ -1158,8 +1274,8 @@ deferred_improvement
 - `planning_gap`：`reopen_current_planning`；只回到真正拥有该事实的上游 SoT，再调用 08 传播受影响范围。
 - `requirement_change`：先按 `02-planning-change-levels.md` 做范围准入，决定本期吸收、增量、下一期或替换本期范围；不得先改 13。
 - `design_drift`：规划仍正确时优先 `fix_in_execution`；设计合同确实需要改变时才回到 05/09/11/13。只有用户路径或业务流程改变时才继续回到 03/01/02。
-- `deferred_improvement`：不影响本期验收且经确认允许延期时，`defer_to_next_phase`；15 已存在则进入其下一期输入区，否则进入已确认 Planning Context 的 `future_phase_inputs`。
-- 15 尚不存在时，将已确认 `future_phase_inputs` 同步为 `current-interaction.yaml` 的最小恢复镜像；Planning Context 仍是临时权威来源。Baseline 已冻结但 14/15 未真实派生时属于框架派生未完成，不得准备 execution-ready Handoff 或进入执行。
+- `deferred_improvement`：不影响本期验收且经确认允许延期时，`defer_to_next_phase`；立即写入 `<requirement_pool_path>`。15 已存在时只在其下一期输入区引用 `POOL-ID`。
+- 15 尚不存在时也直接写 Requirement Pool，并在 `discovery_checkpoint.relevant_requirement_pool_refs` 保留最小引用。Baseline 已冻结但 14/15 未真实派生时属于框架派生未完成，不得准备 execution-ready Handoff 或进入执行。
 
 只有 `planning_gap`、`requirement_change` 或真正改变设计合同的 `design_drift` 可以触发 Planning Recovery 与 SoT 失效传播。
 
@@ -1207,7 +1323,7 @@ candidate -> confirmed -> applied_to_planning -> handoff_prepared -> closed
 - Planning 只定义 15 的更新条件，不填写真实验收、发布或基线更新结果。
 - 只有实际发布确认后才更新生产当前事实；已验收未发布仍保持交付状态。
 - 本期关闭后 00–15 历史只读。旧期次只允许受控修正事实错误，独立新增需求默认进入下一期。
-- 下一期始终从最新 `PROJECT-CURRENT-BASELINE.md` 开始。
+- 下一期始终从最新 `PROJECT-CURRENT-BASELINE.md` 开始，并读取 `<requirement_pool_path>` 做 `same / conflict / unrelated` 判断；需求池不得覆盖当前基线。
 
 ## 10. Planning Document Mode
 
@@ -1302,6 +1418,11 @@ phase_change_target_reconciled_with_current_state
 
 检查：
 
+- `discovery_checkpoint` 已覆盖所有已完成访谈轮次，revision 与 `last_applied_round_id` 一致。
+- 不存在仍为 `recorded` / `validated` 的 Discovery 用户反馈。
+- 会影响本期判断的 `project_evidence / web_research` 未决项已经完成核验，或明确记录无法核验的阻断原因。
+- 纳入 Planning Context 的调研事实具备最小来源、检查时间与证据状态；会影响本期方向的功能候选均有明确的纳入、延期或不适用结论。
+- 已确认延期需求均已写入 `<requirement_pool_path>`，当前检查点只保留 `POOL-ID` 引用。
 - 当前项目状态
 - 目标
 - 范围
@@ -1319,6 +1440,8 @@ phase_change_target_reconciled_with_current_state
 - execution_handoff_decision
 
 是否已确认。
+
+任一 Discovery 轮次未持久化、检查点无法回读或 Requirement Pool 待写入时，Planning Context = INCOMPLETE，不得继续依赖聊天摘要补齐。
 
 --------------------------------------------------
 
@@ -1948,7 +2071,7 @@ Runtime State：
 <phase_planning_runtime_directory>/current-interaction.yaml
 ```
 
-它是上下文压缩、会话恢复和工具中断后的短期恢复来源；其中 `execution_handoff_decision` 与 15 尚不存在时的 `future_phase_inputs` 只是已确认 Planning Context 的最小镜像，`document_assembly` 只是当前装配进度的最小镜像。字段以 `04-planning-format-spec.md` 为准，处理顺序以 `10-planning-document-interaction-runtime.md` 为准，恢复校验以 `08-planning-recovery-runtime.md` 为准。
+它是上下文压缩、会话恢复和工具中断后的短期恢复来源；其中 `discovery_checkpoint` 从第一轮开始保存正在形成的最小 Planning Context 事实，`execution_handoff_decision` 是已确认 Planning Context 的最小分支镜像，`document_assembly` 是当前装配进度的最小镜像。字段以 `04-planning-format-spec.md` 为准，Discovery 处理顺序以本文件 3.2.1 为准，文档交互顺序以 `10-planning-document-interaction-runtime.md` 为准，恢复校验以 `08-planning-recovery-runtime.md` 为准。
 
 Project Runtime Evidence：
 
@@ -2008,7 +2131,7 @@ planning-runtime/
 规则：
 
 - 本 skill 不定义其他 skill 的运行时目录、日志结构、证据保存位置或实际回写机制。
-- `execution_handoff_decision` 第一次需要在发问前持久化时按需创建 `current-interaction.yaml`；不得等到进入 Planning Document Mode 后才创建。
+- 进入 `discovery_start` 且本期路径合法绑定后，在第一条实质性业务问题前创建 `current-interaction.yaml`；后续执行交接和 Document Mode 必须复用同一文件。
 - `event-log.md` 在第一次实际写入 Runtime Event 时创建。
 - `decision-log.md` 在第一次实际存在 Decision Snapshot 时创建。
 - `audit-log.md` 只在真正触发 Runtime Audit 时创建；普通 Planning 不默认创建。
@@ -2350,6 +2473,8 @@ missing_sections:
 
 共同条件：
 
+- Discovery 每轮反馈均已应用并持久化，`discovery_checkpoint.status: compiled_into_planning_context`，不存在只留在聊天或压缩摘要中的有效业务事实。
+- 本期所有确认延期项均已写入 Requirement Pool；所有确认纳入当前期的 `same` 池条目均已删除，已解决的 `conflict` 条目已先更新为用户最新需求。
 - 本期实际装配文档已生成并确认。
 - `assembled_documents` 与 `handoff_role_mapping` 已基于真实路径生成。
 - Handoff Branch Consistency Check 已通过；Planning Context、本期 `current-interaction.yaml` 恢复镜像、Document Assembly Plan 与 Handoff 的分支字段一致，前三者的 `decision_status` 均为 `confirmed`。
@@ -2369,7 +2494,7 @@ missing_sections:
 - `requires_execution_handoff: false`。
 - Handoff 不包含 13/14/15 职责、`planning_baseline_revision`、`active_change_revision`、`execution_constraints` 或 `incremental_execution_contract`，也不使用空值或虚构 revision 占位。
 - 不存在阻断本期规划结论本身的 OPEN。
-- Planning Context 存在已确认 `future_phase_inputs` 时，planning_only Handoff 已承接且没有为此生成 13/14/15。
+- 本期存在延期需求时，Requirement Pool 已成功写入，planning_only Handoff 只承接 `deferred_requirement_refs`，且没有为此生成 13/14/15。
 
 ```yaml
 event_seq:

--- a/skills/planning-layer-runtime/references/08-planning-recovery-runtime.md
+++ b/skills/planning-layer-runtime/references/08-planning-recovery-runtime.md
@@ -101,9 +101,12 @@ Recovery Runtime 只允许：
 
 ```text
 读取本期 current-interaction.yaml
+-> 恢复 discovery_checkpoint revision / last_applied_round_id / active_question
+-> 恢复 unresolved_items 的 resolution_route 与 research_findings
 -> 恢复 active_interaction
 -> 恢复未完成 latest_feedback
 -> 校验反馈与 active_interaction 的目标绑定
+-> discovery_question：核对问题 ID、回答状态、事实写入与下一未决项
 -> document：检查目标正式文档当前状态
 -> final_summary：检查总结版本与 planning_status
 -> 恢复 execution_handoff_decision
@@ -133,6 +136,19 @@ Recovery Runtime 只允许：
 
 禁止根据压缩后的对话摘要、最近提到的文档编号、“下一步是第 X 份”、编号大小或模型记忆推断当前确认对象。
 
+Discovery 恢复规则：
+
+- `latest_feedback` 仍为 `recorded` 或 `validated` 时，先把该回答应用到原 `discovery_question`，更新事实、未决项和 checkpoint revision；不得重问或跳到下一问题。
+- `active_question.answer_status: awaiting_answer` 且无未完成反馈时，向用户自然恢复该问题；不得根据压缩摘要另选问题。
+- `last_applied_round_id` 已完成但 checkpoint revision 未更新，或事实写入与 feedback 结果不一致时，阻止推进并恢复该轮持久化事务。
+- 下一问题必须来自已持久化 `unresolved_items` 与当前最大不确定项；已为 `confirmed` 的事实不得重复询问。
+- `resolution_route: project_evidence | web_research` 的未决项先恢复对应核验事务，不得改成用户问题；已持久化且仍在时效范围内的 `verified` 结论直接复用。
+- 调研结论为 `stale`、`conflicting`、`insufficient`，或所涉版本、价格、法规、平台能力可能已变化时，先重新核验并覆盖更新同一 `research_id`；不得根据压缩摘要或旧聊天结论猜测。
+- 公开来源暂时不可访问时保留已有来源定位并标记需要重新核验；不得删除结论后要求用户回忆公开事实。用户补充唯一内部证据时按项目内来源重新校验。
+- 调研发现的功能候选只有在用户已确认适用、延期或不适用后才能恢复为对应结论；延期项仍以 Requirement Pool 为唯一正文来源。
+- 恢复到非第一次 Planning 的第一阶段时，只读取 `relevant_requirement_pool_refs` 命中的池条目；若尚未执行 Requirement Pool Intake Gate，则按 07 执行，不得扫描 00–15 猜测延期需求。
+- `same` 条目已确认进入当前 Planning Context 后仍存在于池中时，完成消费删除再推进；`conflict` 条目尚未按用户最新确认更新时，恢复到冲突确认；`unrelated` 条目不加载正文。
+
 Planning Context 中已确认的 `execution_handoff_decision` 是权威语义来源，本期 `current-interaction.yaml` 是短期恢复镜像。恢复时：
 
 - `decision_status: confirmed` 且与 Planning Context 一致时，按该分支恢复，不得重新推断。
@@ -149,9 +165,9 @@ Planning Context 中已确认的 `execution_handoff_decision` 是权威语义来
 - `active_change.change_status` 为 `closed` 或 `superseded` 时不得作为当前执行范围恢复；存在连续 Change Set 时只恢复当前 active revision，并通过快照中的 previous/supersedes 引用保留历史关系。
 - `decision_ref` 必须使用 `<phase_planning_runtime_directory>/decision-log.md#decision_id=<DEC-ID>`，并唯一命中同时包含 Change Set 与 Recovery Output 的 Decision Snapshot。只命中文件、标题或时间戳时不得继续恢复。
 - 当前 Snapshot 必须是相对冻结 Baseline 的累计有效增量；它已经包含仍有效前序 Change Set 的影响范围。Recovery 不读取 R2、R3 历史拼装当前状态，也不因 active 指针前移推断旧 revision 已 `closed` 或 `superseded`。
-- 15 尚不存在时，从 `current-interaction.yaml.future_phase_inputs` 恢复已确认 Planning Context 的最小镜像；同步到 15 或 planning_only Handoff 后转读正式承载。Baseline 已冻结但 14/15 缺失时，恢复为框架派生阻断，不得恢复到 `handoff_prepared` 或执行入口。
+- 延期需求只从 `<requirement_pool_path>` 恢复；`current-interaction.yaml.discovery_checkpoint.relevant_requirement_pool_refs`、15 和 Handoff 只提供 `POOL-ID` 定位，不得包含第二份需求正文。Baseline 已冻结但 14/15 缺失时，仍恢复为框架派生阻断，不得恢复到 `handoff_prepared` 或执行入口。
 
-`current-interaction.yaml` 是短期恢复来源，但不是正式 SoT、历史日志或长期聊天记录。不得新增 `recovery-state`、`feedback-runtime`、`confirmation-runtime` 或 `context-compression-runtime`。
+`current-interaction.yaml` 是短期恢复来源，但不是正式 SoT、历史日志、长期聊天记录或研究报告。`discovery_checkpoint` 只保存结构化最小事实、未决项和调研结论，不得扩展为完整访谈历史或网页档案。不得新增 `recovery-state`、`feedback-runtime`、`confirmation-runtime` 或 `context-compression-runtime`。
 
 ## 4. 恢复输出（Recovery Output）
 
@@ -665,6 +681,8 @@ planning-runtime/current-interaction.yaml
 ```
 
 该文件可覆盖更新并作为当前交互恢复来源，不属于 append-only Project Runtime Evidence。
+
+其中 `discovery_checkpoint` 是逐轮覆盖更新的结构化恢复检查点；不得把完整对话、逐字回答或每轮 AI 解释追加成新的日志体系。
 
 规则：
 

--- a/skills/planning-layer-runtime/references/10-planning-document-interaction-runtime.md
+++ b/skills/planning-layer-runtime/references/10-planning-document-interaction-runtime.md
@@ -6,7 +6,7 @@
 
 ## 0. 交互目标与用户反馈事务
 
-`execution_handoff_decision` 第一次需要在发问前持久化时，按 `04-planning-format-spec.md` 的内联格式在当前项目本期目录直接创建或更新：
+Planning Document Mode 必须复用 Discovery 首轮已经按 `04-planning-format-spec.md` 创建的：
 
 ```text
 <phase_planning_runtime_directory>/current-interaction.yaml
@@ -14,7 +14,9 @@
 
 不得从 Skill 目录复制文件。
 
-如果本期目录尚未合法确定，不得把状态暂存到 Skill、`.runtime/planning-layer-runtime/`、项目根目录或其他期次目录；继续 Planning Conversation，直到期次归属可以合法确定。进入 Planning Document Mode 时复用该文件，不得再创建第二个 Planning Context、交接状态或文档装配状态文件。
+如果进入 Planning Document Mode 时该文件不存在，说明逐轮 Discovery 持久化前置未完成，必须回到 `07-planning-conversation-runtime.md#321-discovery-round-transaction` 恢复；不得临时补造一个只含执行交接或文档状态的文件。不得再创建第二个 Planning Context、交接状态或文档装配状态文件。
+
+Discovery 问答事务由 `07` 维护；本文件从执行交接分支确认与文档交互开始继续复用同一 `active_interaction / latest_feedback` 字段，不重复定义 Discovery 生命周期。
 
 ### 0.1 发问前持久化确认目标
 
@@ -79,6 +81,7 @@ active_interaction:
 -> 绑定当前对象
 -> 判断反馈类型
 -> 校验是否允许应用
+-> 若反馈包含会影响规划的可公开核验事实，执行由 07 编排的 Discovery Fact Research Gate，核验并持久化最小来源
 -> 应用到对应文档或阶段
 -> 标记反馈处理结果
 -> 再决定是否进入下一步
@@ -103,6 +106,8 @@ active_interaction:
 - “讲一下”“第 X 份说了什么”记为 `ask_explanation`；只解释目标文档，不改变草案状态。
 - 用户补充事实记为 `supplement`；先判断事实归属的 SoT，再决定是否回写。
 - 用户纠正记为 `correct`；回写真正拥有该事实的上游 SoT，并按 `08-planning-recovery-runtime.md` 检查下游失效。
+- `supplement` 或 `correct` 涉及产品当前能力、版本限制、公开规范、法律监管或其他可核验事实时，必须在反馈已记录后先按 `07` 调研；可靠公开证据可以消除事实提问，但不得未经用户确认改变业务适用性、当前范围或已确认 SoT。
+- 调研发现的新功能或替代方案只作为候选；确认延期时写入 Requirement Pool，确认纳入时回到真正拥有该事实的上游 Planning Context / SoT 并执行失效传播。
 - “先暂停”记为 `pause`；“回到上一份”记为 `return_to_previous`，均不得隐式确认当前草案。
 - 无法可靠分类时记为 `unknown` 与 `needs_clarification`。
 
@@ -325,7 +330,7 @@ Role-Based Document Explanation Gate 发生在正式文档生成后。
 
 规则：
 
-- 正式 SoT 文档中必须保留 `REQ`、`FLOW`、`SCN`、`DOMAIN`、`MODULE`、`CAP`、`PAGE`、`UI-MOD`、`UX-SCN`、`PROMPT-*`、`ASSET`、`STATE`、`API`、`PERM`、`TASK`、`RISK`、`DEP`、`OPEN`、`EXEC`、`TEST` 等 ID。
+- 正式 SoT 文档中必须保留 `REQ`、`FLOW`、`SCN`、`DOMAIN`、`MODULE`、`CAP`、`PAGE`、`UI-MOD`、`UX-SCN`、`PROMPT-*`、`ASSET`、`STATE`、`API`、`PERM`、`TASK`、`RISK`、`DEP`、`OPEN`、`EXEC`、`TEST` 等 ID；引用跨期需求时可以补充 `POOL-ID`，但不得把它当作本期 `REQ-ID`。
 - 用户态解释中不得把 ID 作为主要确认对象。
 - 用户态不得直接问"REQ-001 是否准确？""API-001 是否没问题？""CAP-MAP-001 是否确认？""TASK-001 是否可以执行？"。
 - 用户态必须把 ID 对应的具体内容翻译出来，让使用者确认内容本身。


### PR DESCRIPTION
## 变更内容

- 在第一条实质性问题前创建 `current-interaction.yaml`，逐轮持久化 Discovery 问题、反馈、事实与未决项。
- 新增跨期 Requirement Pool，支持 `same / conflict / unrelated` 比较及延期、更新、消费删除。
- 第一阶段增加本地证据与公开事实调研，保存来源、时效和证据状态。
- 分离 `research_findings` 与业务 `facts`，避免把公开资料冒充用户决策。
- 补齐压缩恢复、文档反馈回流、15/Handoff 引用和完成门禁。

## 验证

- `quick_validate.py skills/planning-layer-runtime`
- `git diff --check`
- `agents/openai.yaml` YAML 解析
- 12 个 Markdown 文件围栏检查
- Requirement Pool 与事实调研前向场景测试

说明：仓库未安装 `node_modules`，因此未运行 Astro 项目级检查。

Closes #2