### PR TITLE
feat(planning): 分批交付可外部生图的 UI/UX Prompt

### DIFF
--- a/skills/planning-layer-runtime/agents/openai.yaml
+++ b/skills/planning-layer-runtime/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "规划层运行时"
   short_description: "逐轮持久化发现，交付可执行规划与 UI/UX 合同"
-  default_prompt: "使用 $planning-layer-runtime 先核实项目证据与可查公开事实，逐轮保存需求发现并维护跨期需求池；第一阶段完成后一次性生成全部适用规划草案，再按队列依次确认并定向修正。涉及前端时生成可复制 Prompt、页面实现合同、UX 状态迁移和版本化资产索引；第二阶段轮到设计文档时，直接把完整 UI Prompt 交给用户并收集、确认 UI 图，再基于已确认 UI 版本交付必要的 UX Prompt 并收集、确认 UX 图，最终形成可由 Long 和 Testing 精确消费的 UI/UX Handoff。"
+  default_prompt: "使用 $planning-layer-runtime 先核实项目证据与可查公开事实，逐轮保存需求发现并维护跨期需求池；第一阶段完成后一次性生成全部适用规划草案，再按队列依次确认并定向修正。涉及前端时生成可复制 Prompt、页面实现合同、UX 状态迁移和版本化资产索引；第二阶段轮到设计文档时，每批最多十条，按稳定序号、title、尺寸建议、参考图片序号和独立 Prompt 文本直接交付，用户可使用任意外部生图工具并按序号回传；逐批确认 UI 图后再基于已确认 UI 版本交付必要的 UX Prompt，循环至全部必需资产确认，最终形成可由 Long 和 Testing 精确消费的 UI/UX Handoff。"

--- a/skills/planning-layer-runtime/references/08-planning-recovery-runtime.md
+++ b/skills/planning-layer-runtime/references/08-planning-recovery-runtime.md
@@ -153,6 +153,7 @@ Recovery Runtime 只允许：
 05 设计资产收集恢复规则：
 
 - 仅从 `design_asset_collection` 恢复当前 `asset_kind / collection_status / active_batch_id`，再读取 05 中对应 Prompt 与 ASSET 正文；不得从压缩摘要猜测用户正在生成 UI 图还是 UX 图。
+- 按 `active_prompt_refs / active_asset_refs` 的持久化顺序恢复当前批次，再从 05 ASSET 的 `image_sequence` 恢复用户态图片序号；批次上限与重发顺序按 10 恢复，用户态格式只按 11 §4.1 渲染。序号缺失、重复或与引用不一致时先阻断并修正 05，不得在恢复时临时重排。
 - `collection_status: prompt_ready` 表示 Prompt 尚未可靠交付：先持久化 `design_asset_generation_request`，再从 05 回读并直接输出完整 `prompt_body`。
 - `collection_status: awaiting_assets` 表示 Prompt 已交付、正在等待图片。恢复时保留已收到资产，只说明仍缺的 ASSET 映射；用户要求重发时从 05 输出同 revision Prompt，不另生成一份。
 - `collection_status: reviewing_assets` 时，必须回读 05 中实际收到的路径、ASSET revision、覆盖状态和 known gaps，恢复 `design_asset_review_confirmation`；不得把“已上传”推断为 `visual_confirmed`。

--- a/skills/planning-layer-runtime/references/10-planning-document-interaction-runtime.md
+++ b/skills/planning-layer-runtime/references/10-planning-document-interaction-runtime.md
@@ -317,11 +317,12 @@ Batch Draft Assembly 发生在任何文档确认前；Role-Based Document Explan
 
 ```text
 Read 05 asset plan and exact Prompt revisions
--> Build one UI asset batch from all same-dependency required STYLE/PAGE/MODULE prompts
+-> Assign or restore every required ASSET's stable image_sequence from 05
+-> Build the next UI asset batch from at most 10 same-dependency required STYLE/PAGE/MODULE prompts
 -> Persist design_asset_collection(prompt_ready) + design_asset_generation_request target
--> Output every required UI prompt_body directly to the user
+-> Output every prompt in this batch directly to the user with the fixed user-facing format
 -> Persist collection_status = awaiting_assets
--> Ask the user to generate or provide the mapped UI images
+-> Ask the user to use any external image-generation tool or provide existing images, mapped by image_sequence
 -> Receive files or external references and persist latest_feedback first
 -> Bind each received image to ASSET-ID@revision and real path/reference
 -> Mark received -> review_pending
@@ -332,8 +333,9 @@ Read 05 asset plan and exact Prompt revisions
 -> User confirms or requests correction
 -> On confirm: mark exact UI ASSET revisions visual_confirmed
 -> On correction: revise only affected Prompt/contract/ASSET revision, return to prompt_ready and resend it
+-> If required UI prompts remain: build the next batch of at most 10 and repeat
 -> Rebuild PROMPT-UX reference_inputs from visual_confirmed UI asset revisions
--> If an interaction image is required: repeat the same batch loop for UX prompts and UX images
+-> If an interaction image is required: repeat the same at-most-10 batch loop for UX prompts and UX images
 -> If existing confirmed UI assets fully express the interaction: record covered_by_existing_ui_assets and skip UX image request
 -> When every required UI/UX asset is visual_confirmed: collection_status = complete
 -> Update 05 Manifest / contracts / coverage and affected downstream drafts
@@ -344,11 +346,13 @@ Read 05 asset plan and exact Prompt revisions
 
 用户态 Prompt 交付规则：
 
-- 必须在聊天回复中直接给出每个本批次资产的用途、目标工具、输出规格、`PROMPT-ID@revision`、对应 `ASSET-ID@revision` 和完整 fenced `prompt_body`。不得只告诉用户“Prompt 已写入 05”、只给文件路径、只给锚点或要求用户自行打开 Markdown 复制。
-- UI Prompt 默认按同一依赖层批量提供，至少包含当前所有必需 STYLE（适用时）、PAGE 和 UI-MOD Prompt；不得无必要地一张图问一轮。UX Prompt 必须在其引用的 UI ASSET revision 已真实收到并完成视觉确认后提供，避免引用不存在或旧版图片。
+- 每个批次只能包含同一依赖层的 `1–10` 条 Prompt；即使剩余项超过 10 条也不得一次性全部输出。依赖边界或剩余数量不足 10 条时允许小批次，不得为了凑满而混入尚不具备依赖的 UX Prompt。
+- 必须在聊天回复中直接按 11 §4.1 的唯一用户态格式交付本批次完整 Prompt，不得在本文件另定义或改写字段模板。不得只告诉用户“Prompt 已写入 05”、只给文件路径、只给锚点或要求用户自行打开 Markdown 复制。
+- 批次开头说明当前批次、预计总批次、当前图片范围和可使用任意外部生图工具。没有内置生图工具不构成阻断，不得因此要求用户配置 API Key、CLI fallback 或特定厂商工具。
+- UI Prompt 按依赖顺序分批提供 STYLE（适用时）、PAGE 和 UI-MOD Prompt；同层超过 10 条时继续下一批，不得无必要地一张图问一轮。UX Prompt 必须在其引用的 UI ASSET revision 已真实收到并完成视觉确认后提供，其 `参考的图片序号` 必须对应这些已确认 UI 图，避免引用不存在、旧版或仅存在于聊天描述中的图片。
 - 用户已经有符合要求的 UI/UX 图时允许直接上传或提供真实外部引用，不强制重新生成；仍必须绑定 ASSET revision 并执行视觉确认。
-- 必须明确告诉用户每张图对应哪个页面、模块或交互，以及建议文件名或回传映射方式，避免多图无法归属。
-- 用户一次只提供部分图片时，已收到项立即持久化并保留；后续只重发缺失或修订项的 Prompt，不要求重新上传未受影响图片。
+- 必须明确告诉用户按稳定图片序号回传，并可同时给出建议文件名，避免多图无法归属。用户一次只提供部分图片时，已收到项立即持久化并保留；后续只列出和重发缺失或修订项，不要求重新上传未受影响图片。
+- 一个批次完成视觉确认后，若仍有必需资产，必须主动交付下一批并重复“Prompt 交付 -> 外部生成/已有图回传 -> 审查 -> 用户确认”；直到全部必需 UI/UX 资产闭合。不得把“本批最多 10 张”误解为总共只处理 10 张，也不得在中途无故结束 05 设计资产收集。
 
 视觉确认规则：
 
@@ -356,6 +360,7 @@ Read 05 asset plan and exact Prompt revisions
 - `visual_confirmed` 只能由绑定当前批次和当前 ASSET revision 的用户确认产生，并写回真实路径/引用、确认来源和时间；一句“确认”不得同时确认图片和 05 文档。
 - 任一必需 UI/UX 图缺失、仍为 `review_pending` 或用户要求重做时，05 不得进入整体文档确认，`design_asset_collection` 保持未完成，相关 UI TASK 不得 Ready。
 - 图片修订必须提升对应 ASSET revision；Prompt 或合同内容变化时同步提升其 revision，并只失效真实依赖旧 revision 的下游草案。
+- 图片修订、批次切换和中断恢复不得重新编号。`design_asset_collection.active_prompt_refs` 与 `active_asset_refs` 按当次展示顺序保存，图片序号的唯一 SoT 仍是 05 ASSET 索引中的 `image_sequence`。
 - 本 Gate 复用 `current-interaction.yaml`、05 ASSET 索引和既有 `UI_CONFIRMATION` 事件；不得新增出图日志、图片确认 Runtime 或第二份设计 SoT。
 
 当前文档为 13 时，人话总结还必须说明：

--- a/skills/planning-layer-runtime/references/11-planning-ui-ux-execution-contract.md
+++ b/skills/planning-layer-runtime/references/11-planning-ui-ux-execution-contract.md
@@ -133,15 +133,28 @@ Prompt 正文必须明确：
 
 ### 4.1 User-Facing Prompt Delivery And Asset Intake
 
-Prompt 写入 05 只是持久化，不等于已经交付给用户。轮到 05 确认时必须：
+Prompt 写入 05 只是持久化，不等于已经交付给用户。批次选择、每批上限、UI/UX 依赖顺序、图片接收、视觉确认和继续条件只按 10 执行，中断恢复只按 08 执行；本节是每条 Prompt 用户态格式与图片序号映射的唯一事实来源。
 
-- 在用户态回复中直接输出完整 fenced `prompt_body`，并同时说明 `PROMPT-ID@revision`、目标工具、输出规格、对应页面/模块/交互和待回传 `ASSET-ID@revision`。
-- 先按同一依赖层批量提供所有必需 STYLE（适用时）、PAGE 与 UI-MOD Prompt，让用户一次生成或提供 UI 图；不得只给文件链接或让用户自己去 05 查找 Prompt。
-- UI 图收到并达到 `visual_confirmed` 后，才允许将其真实路径与 revision 写入 `PROMPT-UX.reference_inputs` 并向用户提供 UX Prompt。需要多帧交互图时，明确帧序、画幅和每帧状态；已有确认 UI 图足以表达时不机械要求额外 UX 图。
+- 主展示必须固定为“序号、`title`、尺寸建议、参考的图片序号、单独 Prompt 文本”，用户无需理解内部 ID 即可复制和回传：
+
+````markdown
+序号：图 01
+title：资料审核页—默认与提交状态
+尺寸建议：桌面端；1440×1024；16:10；2x；4 帧
+参考的图片序号：无
+
+```prompt
+<独立、完整、无需引用聊天上文的 prompt_body>
+```
+````
+
+- `序号` 来自对应 ASSET 的稳定 `image_sequence`，跨批次、恢复与 revision 变化均不得重排；`参考的图片序号` 只引用已真实提供的 ASSET 序号，没有时明确写 `无`。内部 `PROMPT-ID@revision -> ASSET-ID@revision`、目标工具和对应合同继续持久化，并可作为每项末尾的一行追踪信息，但不得取代主展示字段。
+- 批次开头按 10 说明进度，并明确用户可把 Prompt 复制到任意外部生图工具；本格式不得依赖内置 ImageGen、CLI、API Key 或指定供应商。
+- UX Prompt 的“参考的图片序号”必须逐一映射其 `reference_inputs` 中已达到 `visual_confirmed` 的 UI ASSET revision；需要多帧交互图时，Prompt 正文明示帧序、画幅和每帧状态，已有确认 UI 图足以表达时不机械增加 UX 图。
 - 用户可上传自行制作、其他工具生成或既有的 UI/UX 图；Prompt 是方便生成的直接交付，不是接受资产的唯一入口。
-- 用户提供部分资产时保留已收到项，只继续请求缺失项；用户要求调整时仅提升受影响 Prompt、合同和 ASSET revision。
+- 用户按图片序号回传；部分回传、修订与继续行为按 10 处理，且不得改变未受影响 ASSET 的 `image_sequence`。
 
-交互目标、反馈绑定、图片接收、视觉确认和中断恢复以 10 与 08 为准。本节不新增交互 Runtime 或第二份资产状态。
+本节不新增交互 Runtime 或第二份资产状态。
 
 存在必需 UI/UX 图时，只有 `design_asset_collection.collection_status: complete` 且全部对应 ASSET revision 均为 `visual_confirmed`，05 才能通过整体确认；没有必需设计图时必须在 05 明确记录判定依据，不创建空批次。
 
@@ -239,6 +252,7 @@ implementation_acceptance:
 每个 `ASSET` 使用以下字段：
 
 ```yaml
+image_sequence: <本期 05 内唯一且稳定的正整数；用户态显示为图 01>
 asset_revision: <稳定 revision>
 asset_type: <global_style | page_ui | module_ui | ux_interaction>
 asset_status: <planned | prompt_ready | received | review_pending | visual_confirmed | superseded>
@@ -259,6 +273,8 @@ supersedes: <旧 ASSET-ID@revision；不适用时省略>
 
 规则：
 
+- `image_sequence` 是用户态图片映射的唯一序号：同一 ASSET 的所有 revision 保持不变，批次切换、中断恢复、替换或确认顺序变化都不得重编号；新 ASSET 使用本期下一个未占用正整数，已废弃序号不回收。
+- Prompt 展示中的“序号”和“参考的图片序号”必须由 `image_sequence` 渲染。引用图片时仍在内部绑定确切 `ASSET-ID@revision`，不得只保存数字而丢失版本关系。
 - `received` 及以后状态必须有真实路径或外部引用。
 - `source: user_generated` 表示用户使用 Planning 提供的 Prompt 生成后回传；`user_provided` 表示用户直接提供已有图。两者进入执行前都必须经过同一视觉确认。
 - `visual_confirmed` 必须绑定 revision、用户确认来源与确认时间。

--- a/skills/planning-layer-runtime/references/12-planning-ui-ux-execution-example.md
+++ b/skills/planning-layer-runtime/references/12-planning-ui-ux-execution-example.md
@@ -302,6 +302,7 @@ covered_by_asset_ref: ASSET-PROFILE-UX-001@asset-r2
 ### ASSET-PROFILE-PAGE-001
 
 ```yaml
+image_sequence: 1
 asset_revision: asset-r3
 asset_type: page_ui
 asset_status: visual_confirmed
@@ -329,6 +330,7 @@ confirmed_at: '2026-08-22T10:00:00+09:00'
 ### ASSET-PROFILE-UX-001
 
 ```yaml
+image_sequence: 2
 asset_revision: asset-r2
 asset_type: ux_interaction
 asset_status: visual_confirmed

--- a/skills/planning-layer-runtime/scripts/validate_ui_ux_contract.py
+++ b/skills/planning-layer-runtime/scripts/validate_ui_ux_contract.py
@@ -277,6 +277,22 @@ def validate_interactions(text: str, result: ValidationResult) -> dict[str, str]
 def validate_assets(text: str, manifest: str, result: ValidationResult) -> dict[str, str]:
     blocks = extract_heading_blocks(text, r"ASSET-[A-Z0-9-]+")
     result.require(bool(blocks), "no ASSET contract found")
+    seen_sequences: dict[int, str] = {}
+    for asset_id, block in blocks.items():
+        require_fields(asset_id, block, ["image_sequence"], result)
+        sequence_value = extract_yaml_mapping_value(block, "image_sequence")
+        sequence_valid = bool(sequence_value and re.fullmatch(r"[1-9]\d*", sequence_value))
+        result.require(sequence_valid, f"{asset_id}: image_sequence must be a positive integer")
+        if not sequence_valid:
+            continue
+        sequence = int(sequence_value)
+        previous_asset = seen_sequences.get(sequence)
+        result.require(
+            previous_asset is None,
+            f"{asset_id}: duplicate image_sequence {sequence} already used by {previous_asset}",
+        )
+        if previous_asset is None:
+            seen_sequences[sequence] = asset_id
     confirmed_ids = set(re.findall(r"ASSET-[A-Z0-9-]+", manifest))
     for asset_id in confirmed_ids:
         block = blocks.get(asset_id, "")
@@ -287,6 +303,7 @@ def validate_assets(text: str, manifest: str, result: ValidationResult) -> dict[
             asset_id,
             block,
             [
+                "image_sequence",
                 "asset_revision",
                 "asset_type",
                 "asset_status",


### PR DESCRIPTION
Closes #6

## 变更摘要

- Planning 第二阶段轮到 05 时，必须在聊天中直接交付完整 UI/UX Prompt；
- 同一依赖层每批最多 10 条，完成确认后继续下一批，直到全部必需资产闭合；
- 固定用户态格式：序号、title、尺寸建议、参考的图片序号、独立 Prompt 文本；
- 用户可使用任意外部生图工具，流程不依赖 ImageGen、CLI、API Key 或特定供应商；
- UI 图先接收并视觉确认，UX Prompt 只能引用已确认 UI ASSET revision；
- 支持部分回传、定向修订和上下文压缩后的稳定恢复。

## 持久化与校验

- 在既有 ASSET 合同增加稳定且唯一的 `image_sequence`；
- `image_sequence` 跨批次、恢复和资产 revision 保持不变；
- 校验器新增正整数与唯一性检查；
- 完整结构示例已同步。

## 低熵设计

- 11 是用户态 Prompt 格式与图片序号映射的唯一事实来源；
- 10 只定义批次和交互顺序；
- 08 只定义恢复引用；
- 复用现有 `current-interaction.yaml`、05 ASSET 索引和 UI_CONFIRMATION；
- 不新增 Runtime、日志、第二份资产清单或 README。

## 验证

- `quick_validate.py`：通过；
- `validate_ui_ux_contract.py` 完整示例：通过；
- 重复 `image_sequence` 反向用例：正确拒绝；
- Prompt 固定模板唯一来源检查：通过；
- Python 编译检查：通过；
- `git diff --check`：通过。