### PR TITLE
feat: add versioned Runtime Skill synchronization

### DIFF
--- a/.github/workflows/release-skills.yml
+++ b/.github/workflows/release-skills.yml
@@ -1,0 +1,30 @@
+name: Release Runtime Skills
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tagged source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Validate release tag and manifest
+        run: python scripts/validate-skill-manifest.py --release-tag "$GITHUB_REF_NAME"
+      - name: Test synchronization tool
+        run: python -m unittest discover -s tests -p 'test_*.py'
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes --title "$GITHUB_REF_NAME"

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,43 @@
+name: Validate Runtime Skills
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+      - 'scripts/**'
+      - 'tests/**'
+      - 'skills-manifest.json'
+      - '.github/workflows/validate-skills.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'skills/**'
+      - 'scripts/**'
+      - 'tests/**'
+      - 'skills-manifest.json'
+      - '.github/workflows/validate-skills.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Validate manifest and version bumps
+        if: github.event_name == 'pull_request'
+        run: python scripts/validate-skill-manifest.py --compare-ref "${{ github.event.pull_request.base.sha }}"
+      - name: Validate manifest
+        if: github.event_name != 'pull_request'
+        run: python scripts/validate-skill-manifest.py
+      - name: Test synchronization tool
+        run: python -m unittest discover -s tests -p 'test_*.py'

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 .playwright-cli/
 .DS_Store
 npm-debug.log*
+__pycache__/
+*.py[cod]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,17 +32,29 @@ Agent 必须扫描目标仓库实际存在的 Skill 目录，先读取每个候�
 → 按其路由加载必要资源
 ```
 
-## 3. 安装到外部项目
+## 3. 版本检查、同步与期次锁定
 
-1. 复制所需 Skill 的完整目录并保持内部相对路径不变。
-2. 同时复制 `SKILL.md`、`agents/` 元数据、references、Profiles、模板和必要 Runtime bootstrap 资产；不要只复制单个 `SKILL.md`。
-3. 不复制其他项目已经填写的环境事实或运行状态。`ai-code-inspection` 安装包中的 `assets/runtime-templates/` 只作为初始化源；首次使用时在目标项目根目录创建 `.runtime/ai-code-inspection/`，环境档案从 `uninitialized` 模板开始，运行状态从空闲模板开始。
-4. 目标项目已有 `AGENTS.md` 时合并适用规则，不得直接覆盖。
-5. 根据目标 Agent 平台和项目约定选择项目级 Skill 目录。可能的目录例如但不限于 `.skills/`、`.agents/skills/`、`.claude/skills/`、`.codex/skills/`。
-6. 实际路径由所使用的 Agent 平台和项目约定决定；不得把任一示例目录视为唯一安装方式。
-7. 平台没有固定 Skill 目录时，在目标项目的 `AGENTS.md` 中声明每个 Skill 的真实位置和发现方式。
+- `skills-manifest.json` 是仓库当前版本事实的唯一来源；不得从 `package.json`、README、`SKILL.md` 或文件修改时间推断 Skill 版本。
+- 目标项目必须提交根目录 `runtime-skills.lock.json`。它记录来源 Release、commit、每个 Skill 版本、全部安装位置和内容摘要；不同 Agent 平台不得维护彼此独立的版本事实。
+- 目标项目存在锁文件时，每个 Agent 会话第一次使用任一 Runtime Skill 前，先运行 `python .runtime-skills/runtime-skills.py sync --project .`。同一会话且锁文件未变化时不重复检查。
+- `sync` 只在无本地漂移、无期次锁定且更新为兼容补丁版本时自动更新。次版本或主版本变化必须先展示版本差异并取得用户确认。
+- 任何受管 Skill 或同步工具与锁文件摘要不一致时，停止自动覆盖，先运行 `diff` 并让用户决定保留本地修改还是采用发布版本。
+- 新期次开始前先完成同步，再运行 `pin --reason <期次或任务标识>`。从 Planning 建立期次开始，到 Long、Testing 和期次关闭之间保持同一版本；不得在活动期次中途自动换版。
+- 只有期次已经关闭，或用户明确批准迁移并接受重新校验现有 Runtime/合同后，才运行 `unpin` 并更新。
+- 网络或 GitHub 不可用时，至少运行 `verify`。本地副本全部匹配锁文件时可以继续使用已锁版本，但必须报告没有完成远端更新检查。
 
-## 4. 首次项目初始化
+## 4. 安装到外部项目
+
+1. 优先运行 `scripts/runtime-skills.py install --release latest`，由同步工具从最新稳定 Release 复制完整 Skill 目录、安装目标项目级同步入口并生成锁文件；不要以手工复制作为正常安装流程。只有维护者明确验证未发布内容时才使用 `--source`。
+2. 安装时同时复制 `SKILL.md`、`agents/` 元数据、references、Profiles、模板和必要 Runtime bootstrap 资产；不要只复制单个 `SKILL.md`。
+3. 多平台共用时，在同一次安装中传入全部目标 Skill 根目录。工具必须把所有副本绑定到同一锁文件和同一 Release。
+4. 不复制其他项目已经填写的环境事实或运行状态。`ai-code-inspection` 安装包中的 `assets/runtime-templates/` 只作为初始化源；首次使用时在目标项目根目录创建 `.runtime/ai-code-inspection/`，环境档案从 `uninitialized` 模板开始，运行状态从空闲模板开始。
+5. 目标项目已有 `AGENTS.md` 时合并适用规则，不得直接覆盖。
+6. 根据目标 Agent 平台和项目约定选择项目级 Skill 目录。可能的目录例如但不限于 `.skills/`、`.agents/skills/`、`.claude/skills/`、`.codex/skills/`。
+7. 实际路径由所使用的 Agent 平台和项目约定决定；不得把任一示例目录视为唯一安装方式。
+8. 平台没有固定 Skill 目录时，在目标项目的 `AGENTS.md` 中声明每个 Skill 的真实位置和发现方式。
+
+## 5. 首次项目初始化
 
 Agent 第一次在目标项目使用需要环境事实的 Skill 时，先执行：
 
@@ -61,7 +73,7 @@ Agent 第一次在目标项目使用需要环境事实的 Skill 时，先执行�
 
 初始化只使用当前仓库证据和用户明确提供的约束。不得从 Skill 示例或其他项目推断技术栈；不得默认使用 Vue、React、NestJS、Prisma、TypeScript、某个 package manager、测试命令或数据库迁移命令。无法可靠确认的事实保持未确认并报告。
 
-## 5. Skill 选择规则
+## 6. Skill 选择规则
 
 ```text
 用户请求
@@ -82,7 +94,7 @@ Agent 第一次在目标项目使用需要环境事实的 Skill 时，先执行�
 - 不让发布流程代替日常代码检查。
 - 必要时按 `planning → implementation → testing → 项目发布/安全流程` 顺序切换；每个阶段只保留一个主治理 Skill，完成明确 handoff 后再切换。
 
-## 6. 项目适配原则
+## 7. 项目适配原则
 
 通用 Skill 源文件不得存放目标项目的业务参数和长期环境事实。项目特定信息只写入：
 
@@ -93,7 +105,7 @@ Agent 第一次在目标项目使用需要环境事实的 Skill 时，先执行�
 
 不得把项目名称、业务模块、企业名称、固定端口、固定域名、私有路径、用户名、密钥、真实数据库地址、真实部署环境或单个项目的 package script 回写到通用 Skill 源文件。
 
-## 7. 规则优先级
+## 8. 规则优先级
 
 在不与 Agent 平台或其他更高优先级指令冲突的前提下，仓库内按以下顺序解释：
 
@@ -113,7 +125,7 @@ Agent 第一次在目标项目使用需要环境事实的 Skill 时，先执行�
 - 技术栈 Profile 不得重新定义场景、范围、授权、问题分类或生命周期。
 - 项目代码与正式契约冲突时，按选中 Skill 定义的事实优先级取证；没有明确依据时不得自行猜测。
 
-## 8. 安全与修改原则
+## 9. 安全与修改原则
 
 - 先识别检查范围与修改范围；读取权限不等于修改权限。
 - 不修改范围外文件，不覆盖或清理用户未提交改动。
@@ -123,14 +135,15 @@ Agent 第一次在目标项目使用需要环境事实的 Skill 时，先执行�
 - 修改后运行目标项目已有的适用 build、test、lint、typecheck、schema 或契约验证命令。
 - 无法验证时明确报告未执行项、原因和剩余风险。
 
-## 9. 外部用户快速开始
+## 10. 外部用户快速开始
 
-1. 将需要的 Skill 完整复制到项目。
+1. 使用同步工具安装所需 Skill，并把 `runtime-skills.lock.json` 提交到目标项目。
 2. 在项目顶层放置或合并本 `AGENTS.md` 的适用入口规则。
-3. 让 Agent 扫描项目并初始化各已选 Skill 需要的环境档案或 Runtime 目录。
-4. 先运行只读检查验证适配结果。
-5. 确认识别出的技术栈、命令、范围和权限正确。
-6. 再执行明确允许修改的任务。
+3. 运行 `verify`，确认所有 Agent 平台副本与锁文件一致。
+4. 让 Agent 扫描项目并初始化各已选 Skill 需要的环境档案或 Runtime 目录。
+5. 先运行只读检查验证适配结果。
+6. 确认识别出的技术栈、命令、范围和权限正确。
+7. 再执行明确允许修改的任务。
 
 通用示例指令：
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A project-neutral set of Agent Skills for planning, implementation, testing, and code inspection. The repository contains reusable governance only; project-specific commands, credentials, paths, and environment facts stay in the target project.
 
-Only the selected directories under `skills/` are installable Skill packages. `AGENTS.md` is the reusable project-entry template. `src/`, `public/`, `package*.json`, `astro.config.mjs`, `tsconfig.json`, and the documentation deployment workflow belong to this repository's Astro/Starlight documentation site and must not be copied into a target project.
+Only the selected directories under `skills/` are installable Skill packages. `AGENTS.md` is the reusable project-entry template. `src/`, `public/`, `package*.json`, `astro.config.mjs`, `tsconfig.json`, and the documentation deployment workflow belong to this repository's Astro/Starlight documentation site and must not be copied into a target project. The version in `package.json` belongs to the documentation site and is not a Skill version.
 
 ## The four skills
 
@@ -30,9 +30,32 @@ planning-layer-runtime
 
 After the planning baseline is frozen, accepted requirement or contract changes use an append-only Change Set and an incremental handoff. Long executes only the selected queues, and Testing classifies findings before routing them; neither stage reopens or reruns the whole phase by default.
 
+## Versions and automatic synchronization
+
+The repository has two version levels: a GitHub Release identifies one jointly validated bundle, while each Skill has its own SemVer in [`skills-manifest.json`](skills-manifest.json). Neither the README nor `SKILL.md` is a version source.
+
+An installed target project receives:
+
+```text
+runtime-skills.lock.json               # release, commit, Skill versions, destinations, hashes
+.runtime-skills/runtime-skills.py      # project-local synchronization entry point
+```
+
+Commit the lock file in the target project. It binds copies under `.agents/skills/`, `.claude/skills/`, and other platform directories to the same Release so different Agents cannot silently use mixed versions.
+
+Before the first Runtime Skill use in each Agent session, run:
+
+```bash
+python .runtime-skills/runtime-skills.py sync --project .
+```
+
+Compatible patch updates are applied automatically by default. Minor and major updates are reported for confirmation. Local modifications or destination drift stop replacement. Pin an active phase so Planning, Long, and Testing keep using the same rules, then unpin after the phase closes.
+
+See [Versioning and updates](src/content/docs/reference/versioning-and-updates.md) for the full command and release policy.
+
 ## Install in an Agent project
 
-No manual file copying is required. Give the Agent read access to this repository and write access to the target project, then run the initialization prompt below.
+No manual file copying is required. Give the Agent read access to this repository and write access to the target project, then run the initialization prompt below. The Agent should invoke the synchronization tool instead of maintaining an unversioned copy workflow.
 
 The user only needs to provide a target project name, local path, or repository URL, plus the Agent platform and Skills to install. With sufficient permissions, the Agent locates the project, copies each selected Skill as a complete directory, and adapts it without requiring the user to move or edit files manually.
 
@@ -48,6 +71,9 @@ The installation created by the Agent can look like this when all three platform
 your-project/
 ├── AGENTS.md
 ├── CLAUDE.md                   # only needed by Claude Code
+├── runtime-skills.lock.json
+├── .runtime-skills/
+│   └── runtime-skills.py
 ├── .agents/skills/             # Codex + GitHub Copilot
 │   ├── ai-code-inspection/
 │   ├── planning-layer-runtime/
@@ -83,16 +109,28 @@ Install and initialize Runtime Skills for the following target project:
 Take responsibility for the complete initialization. Do not ask me to copy, paste, or edit installation files manually.
 Use the supplied project name or address to search the workspaces and repositories you can access. If exactly one matching local project is found, continue automatically. Ask me only when the target is missing, ambiguous, or outside your permissions.
 Confirm internally that the source is this Skill repository and that the destination is the matched target project before writing.
-From this repository, copy only the complete directories of the selected Skills under skills/ into the project-level Skill directory supported by the selected Agent platform.
+Run scripts/runtime-skills.py install --release latest to place the complete selected Skill directories from the latest stable Release in the project-level Skill directory supported by the selected Agent platform. Also create runtime-skills.lock.json and the project-local synchronization entry point. Pass every target directory in the same installation when multiple Agent platforms are used.
 Merge the applicable routing and safety rules from this repository's AGENTS.md into the target project's AGENTS.md; never overwrite existing project instructions. For Claude Code, also create or merge CLAUDE.md so it imports AGENTS.md.
 Do not copy this repository's README files, src/, public/, package.json, package-lock.json, astro.config.mjs, tsconfig.json, .github/workflows/, or any other documentation-site files.
 Scan only the target project, list the installed Skills, and adapt their stable environment profiles or bootstrap files using facts from that project.
 Do not create task/phase Runtime state before its skill entry gate is satisfied.
 Do not modify business code, run database migrations, deploy, commit, or push.
-Report the copied, merged, and initialized files; detected components, languages, frameworks, persistence, test tools, CI workflows, and validation commands; and any unresolved facts.
+Run the synchronization tool's verify command. Report the installed Release, commit, every Skill version and destination; copied, merged, and initialized files; detected components, languages, frameworks, persistence, test tools, CI workflows, and validation commands; and any unresolved facts.
 ```
 
 AI initialization means locating the named target, installing the selected Skill packages, merging the Agent entry instructions, and adapting Skill-owned profiles or bootstrap files. It does not migrate this repository or its documentation site into that project.
+
+You can also run the tool directly from this repository. For example, to install for both Codex and Claude Code:
+
+```bash
+python scripts/runtime-skills.py install \
+  --release latest \
+  --project /path/to/your-project \
+  --skill planning-layer-runtime \
+  --skill long-task-orchestrator \
+  --destination .agents/skills \
+  --destination .claude/skills
+```
 
 ## Use the skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 这是一套与具体项目无关的 Agent Skills，负责开发规划、实现、测试和代码检查。仓库只保存可复用治理；目标项目的命令、账号、路径和环境事实必须留在目标项目中。
 
-只有 `skills/` 下被选中的目录属于可安装 Skill 包；`AGENTS.md` 是可复用的项目入口模板。`src/`、`public/`、`package*.json`、`astro.config.mjs`、`tsconfig.json` 和文档部署 workflow 只用于构建本仓库的 Astro/Starlight 文档站，不能复制到目标项目。
+只有 `skills/` 下被选中的目录属于可安装 Skill 包；`AGENTS.md` 是可复用的项目入口模板。`src/`、`public/`、`package*.json`、`astro.config.mjs`、`tsconfig.json` 和文档部署 workflow 只用于构建本仓库的 Astro/Starlight 文档站，不能复制到目标项目。`package.json` 的版本属于文档站，不代表任何 Skill 版本。
 
 ## 四个 Skill
 
@@ -30,9 +30,32 @@ planning-layer-runtime
 
 Planning Execution Baseline 冻结后，已接受的需求或合同变化通过追加式 Change Set 和增量 Handoff 流转。Long 只消费被选中的执行队列，Testing 先分类再回流；默认不会重开或重跑整个期次。
 
+## 版本与自动同步
+
+仓库采用两个版本层级：GitHub Release 表示一组经过共同验证的 Skill 快照，每个 Skill 在 [`skills-manifest.json`](skills-manifest.json) 中拥有独立 SemVer。README 和 `SKILL.md` 都不是版本事实源。
+
+安装后，目标项目会得到：
+
+```text
+runtime-skills.lock.json               # 已安装 Release、commit、Skill 版本、目标位置和内容摘要
+.runtime-skills/runtime-skills.py      # 项目内同步入口
+```
+
+把锁文件提交到目标项目 Git。它会把 `.agents/skills/`、`.claude/skills/` 等多个副本绑定到同一 Release，避免不同 Agent 使用新旧混合规则。
+
+每个 Agent 会话第一次使用 Runtime Skill 前运行：
+
+```bash
+python .runtime-skills/runtime-skills.py sync --project .
+```
+
+默认自动安装兼容的补丁更新；次版本和主版本更新只报告差异，等待用户确认。存在本地修改或多平台副本漂移时停止覆盖。活动期次应先 `pin`，保持 Planning、Long 和 Testing 使用同一套规则，期次关闭后再 `unpin`。
+
+完整命令、退出行为和版本升级规则见[版本与更新机制](src/content/docs/reference/versioning-and-updates.md)。
+
 ## 部署到 Agent 项目
 
-不需要用户手动复制文件。只需让 Agent 同时拥有本仓库的读取权限和目标项目的写入权限，然后运行下方初始化 Prompt。
+不需要用户手动复制文件。只需让 Agent 同时拥有本仓库的读取权限和目标项目的写入权限，然后运行下方初始化 Prompt。Agent 应调用同步工具，不再自行维护一套无版本复制逻辑。
 
 用户只需提供目标项目名称、本地路径或仓库地址，以及 Agent 平台和需要安装的 Skill。有足够权限时，Agent 会自行定位项目、完整复制所选 Skill 并完成适配，不要求用户手动搬运或编辑文件。
 
@@ -48,6 +71,9 @@ Planning Execution Baseline 冻结后，已接受的需求或合同变化通过�
 your-project/
 ├── AGENTS.md
 ├── CLAUDE.md                   # 仅 Claude Code 需要
+├── runtime-skills.lock.json
+├── .runtime-skills/
+│   └── runtime-skills.py
 ├── .agents/skills/             # Codex + GitHub Copilot
 │   ├── ai-code-inspection/
 │   ├── planning-layer-runtime/
@@ -83,16 +109,28 @@ Claude Code 不会直接读取 `AGENTS.md`，因此 Agent 会创建或合并这�
 请完整负责本次初始化，不要要求我手动复制、粘贴或编辑安装文件。
 根据我提供的项目名称或地址，在你有权限访问的工作区和仓库中搜索目标项目。只找到一个匹配的本地项目时直接继续；仅在找不到目标、存在多个匹配或权限不足时再询问我。
 写入前自行确认来源是当前 Skill 仓库，目标是搜索到的目标项目。
-从本仓库中只复制 skills/ 下已选择 Skill 的完整目录，并放入该 Agent 平台支持的项目级 Skill 目录。
+运行 scripts/runtime-skills.py install --release latest，从最新稳定 Release 将已选择 Skill 的完整目录放入该 Agent 平台支持的项目级 Skill 目录；同时生成 runtime-skills.lock.json 和项目内同步入口。多个 Agent 平台必须在同一次安装中传入全部目标目录。
 将本仓库 AGENTS.md 中适用的路由与安全规则合并到目标项目的 AGENTS.md，绝不覆盖目标项目已有指令。使用 Claude Code 时，还要创建或合并 CLAUDE.md，使其导入 AGENTS.md。
 不要复制本仓库的 README、src/、public/、package.json、package-lock.json、astro.config.mjs、tsconfig.json、.github/workflows/ 或任何其他文档站文件。
 只扫描目标项目，列出已安装 Skill，并根据该项目的真实事实适配 Skill 自有的稳定环境档案或启动文件。
 在对应 Skill 的进入条件满足前，不要创建任务或期次 Runtime 状态。
 不要修改业务代码，不执行数据库迁移、部署、commit 或 push。
-报告本次复制、合并和初始化的文件；识别出的组件、语言、框架、持久化方案、测试工具、CI workflow 和验证命令；以及仍未确认的事实。
+运行同步工具的 verify，报告安装的 Release、commit、每个 Skill 版本、全部安装位置；本次复制、合并和初始化的文件；识别出的组件、语言、框架、持久化方案、测试工具、CI workflow 和验证命令；以及仍未确认的事实。
 ```
 
 AI 初始化只包括：定位指定目标、安装选中的 Skill 包、合并 Agent 入口指令，以及适配 Skill 自有的环境档案或启动文件。它不代表迁移本仓库，更不会把本仓库的文档站搬进目标项目。
+
+也可以直接从本仓库运行同步工具。例如同时安装给 Codex 和 Claude Code：
+
+```bash
+python scripts/runtime-skills.py install \
+  --release latest \
+  --project /path/to/your-project \
+  --skill planning-layer-runtime \
+  --skill long-task-orchestrator \
+  --destination .agents/skills \
+  --destination .claude/skills
+```
 
 ## 开始使用
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -46,6 +46,7 @@ export default defineConfig({
           label: '参考',
           items: [
             { label: 'Skill 目录', slug: 'reference/skill-catalog' },
+            { label: '版本与更新机制', slug: 'reference/versioning-and-updates' },
             { label: '编写新教程', slug: 'authoring/writing-tutorials' },
           ],
         },

--- a/scripts/runtime-skills.py
+++ b/scripts/runtime-skills.py
@@ -1,0 +1,1037 @@
+#!/usr/bin/env python3
+"""Install, verify, and update versioned Runtime Skills without dependencies."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+import zipfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, Sequence
+
+
+TOOL_VERSION = "0.1.0"
+SUPPORTED_SCHEMA_VERSION = 1
+MANIFEST_NAME = "skills-manifest.json"
+LOCK_NAME = "runtime-skills.lock.json"
+INSTALLED_TOOL_PATH = ".runtime-skills/runtime-skills.py"
+SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+IGNORED_FILE_NAMES = {".DS_Store"}
+IGNORED_DIRECTORY_NAMES = {"__pycache__"}
+
+
+class RuntimeSkillsError(RuntimeError):
+    """Expected user-facing failure."""
+
+
+@dataclass
+class SourceBundle:
+    root: Path
+    manifest: dict[str, Any]
+    ref: str
+    commit: str | None
+    temporary_root: Path | None = None
+
+    def close(self) -> None:
+        if self.temporary_root:
+            shutil.rmtree(self.temporary_root, ignore_errors=True)
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RuntimeSkillsError(f"Missing required file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeSkillsError(f"Invalid JSON in {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise RuntimeSkillsError(f"Expected a JSON object in {path}")
+    return value
+
+
+def write_json_atomic(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    temporary.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    os.replace(temporary, path)
+
+
+def parse_semver(value: str, label: str = "version") -> tuple[int, int, int]:
+    match = SEMVER_RE.fullmatch(value)
+    if not match:
+        raise RuntimeSkillsError(
+            f"{label} must use stable SemVer MAJOR.MINOR.PATCH, got {value!r}"
+        )
+    return tuple(int(part) for part in match.groups())
+
+
+def version_change(old: str, new: str) -> str:
+    before = parse_semver(old, "installed version")
+    after = parse_semver(new, "source version")
+    if after < before:
+        return "downgrade"
+    if after == before:
+        return "none"
+    if after[0] != before[0]:
+        return "major"
+    if after[1] != before[1]:
+        return "minor"
+    return "patch"
+
+
+def validate_manifest(manifest: dict[str, Any], root: Path | None = None) -> list[str]:
+    errors: list[str] = []
+    if manifest.get("schema_version") != SUPPORTED_SCHEMA_VERSION:
+        errors.append(
+            f"schema_version must be {SUPPORTED_SCHEMA_VERSION}, got "
+            f"{manifest.get('schema_version')!r}"
+        )
+
+    try:
+        parse_semver(str(manifest.get("release_version", "")), "release_version")
+    except RuntimeSkillsError as exc:
+        errors.append(str(exc))
+
+    repository = manifest.get("repository")
+    if not isinstance(repository, dict) or not repository.get("url"):
+        errors.append("repository.url is required")
+
+    tool = manifest.get("tool")
+    if not isinstance(tool, dict):
+        errors.append("tool must be an object")
+    else:
+        try:
+            parse_semver(str(tool.get("version", "")), "tool.version")
+        except RuntimeSkillsError as exc:
+            errors.append(str(exc))
+        if not tool.get("path"):
+            errors.append("tool.path is required")
+
+    skills = manifest.get("skills")
+    if not isinstance(skills, dict) or not skills:
+        errors.append("skills must be a non-empty object")
+        return errors
+
+    seen_paths: set[str] = set()
+    for name, record in sorted(skills.items()):
+        if not re.fullmatch(r"[a-z0-9-]+", name):
+            errors.append(f"Invalid skill name: {name!r}")
+        if not isinstance(record, dict):
+            errors.append(f"skills.{name} must be an object")
+            continue
+        try:
+            parse_semver(str(record.get("version", "")), f"skills.{name}.version")
+        except RuntimeSkillsError as exc:
+            errors.append(str(exc))
+        skill_path = record.get("path")
+        if not isinstance(skill_path, str) or not skill_path:
+            errors.append(f"skills.{name}.path is required")
+            continue
+        if skill_path in seen_paths:
+            errors.append(f"Duplicate skill path: {skill_path}")
+        seen_paths.add(skill_path)
+        if root is not None:
+            resolved = root / skill_path
+            if not (resolved / "SKILL.md").is_file():
+                errors.append(f"skills.{name}.path has no SKILL.md: {skill_path}")
+
+    if root is not None and isinstance(tool, dict) and tool.get("path"):
+        tool_path = root / str(tool["path"])
+        if not tool_path.is_file():
+            errors.append(f"tool.path does not exist: {tool['path']}")
+    return errors
+
+
+def load_manifest(root: Path) -> dict[str, Any]:
+    manifest = read_json(root / MANIFEST_NAME)
+    errors = validate_manifest(manifest, root)
+    if errors:
+        raise RuntimeSkillsError("Invalid manifest:\n- " + "\n- ".join(errors))
+    return manifest
+
+
+def safe_project_path(project: Path, relative: str) -> Path:
+    candidate = Path(relative)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise RuntimeSkillsError(f"Project paths must be safe and relative: {relative!r}")
+    project_resolved = project.resolve()
+    resolved = (project / candidate).resolve()
+    if resolved == project_resolved or project_resolved not in resolved.parents:
+        raise RuntimeSkillsError(f"Path escapes the target project: {relative!r}")
+    return resolved
+
+
+def iter_content_files(root: Path) -> Iterator[Path]:
+    for path in sorted(root.rglob("*"), key=lambda item: item.as_posix()):
+        relative = path.relative_to(root)
+        if any(part in IGNORED_DIRECTORY_NAMES for part in relative.parts):
+            continue
+        if path.name in IGNORED_FILE_NAMES:
+            continue
+        if path.is_symlink():
+            raise RuntimeSkillsError(f"Symlinks are not supported in managed content: {path}")
+        if path.is_file():
+            yield path
+
+
+def content_hash(root: Path) -> str:
+    if not root.is_dir():
+        raise RuntimeSkillsError(f"Managed directory is missing: {root}")
+    digest = hashlib.sha256()
+    for path in iter_content_files(root):
+        relative = path.relative_to(root).as_posix().encode("utf-8")
+        payload = path.read_bytes()
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        digest.update(len(payload).to_bytes(8, "big"))
+        digest.update(payload)
+    return digest.hexdigest()
+
+
+def file_hash(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def file_inventory(root: Path) -> dict[str, str]:
+    return {
+        path.relative_to(root).as_posix(): file_hash(path)
+        for path in iter_content_files(root)
+    }
+
+
+def git_value(root: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def locate_local_source(script_path: Path) -> Path | None:
+    for candidate in [script_path.parent.parent, *script_path.parents]:
+        if (candidate / MANIFEST_NAME).is_file():
+            return candidate.resolve()
+    return None
+
+
+def parse_github_repository(repository: str) -> tuple[str, str]:
+    parsed = urllib.parse.urlparse(repository)
+    if parsed.scheme != "https" or parsed.netloc.lower() != "github.com":
+        raise RuntimeSkillsError(
+            "Remote release synchronization currently requires an https://github.com/owner/repo URL"
+        )
+    parts = [part for part in parsed.path.strip("/").split("/") if part]
+    if len(parts) != 2:
+        raise RuntimeSkillsError(f"Invalid GitHub repository URL: {repository}")
+    owner, repo = parts
+    if repo.endswith(".git"):
+        repo = repo[:-4]
+    return owner, repo
+
+
+def github_request(url: str) -> urllib.request.Request:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "dev-runtime-skill-sync",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return urllib.request.Request(url, headers=headers)
+
+
+def fetch_json(url: str) -> dict[str, Any]:
+    try:
+        with urllib.request.urlopen(github_request(url), timeout=30) as response:
+            value = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise RuntimeSkillsError(f"Unable to read GitHub release metadata: {exc}") from exc
+    if not isinstance(value, dict):
+        raise RuntimeSkillsError("GitHub returned unexpected release metadata")
+    return value
+
+
+def download(url: str, destination: Path) -> None:
+    try:
+        with urllib.request.urlopen(github_request(url), timeout=60) as response:
+            with destination.open("wb") as output:
+                shutil.copyfileobj(response, output)
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise RuntimeSkillsError(f"Unable to download release archive: {exc}") from exc
+
+
+def extract_zip_safely(archive: Path, destination: Path) -> Path:
+    destination_resolved = destination.resolve()
+    with zipfile.ZipFile(archive) as bundle:
+        for member in bundle.infolist():
+            member_path = (destination / member.filename).resolve()
+            if member_path != destination_resolved and destination_resolved not in member_path.parents:
+                raise RuntimeSkillsError("Release archive contains an unsafe path")
+        bundle.extractall(destination)
+    roots = [path for path in destination.iterdir() if path.is_dir()]
+    if len(roots) != 1:
+        raise RuntimeSkillsError("Release archive must contain exactly one repository root")
+    return roots[0]
+
+
+def remote_source(repository: str, release_name: str) -> SourceBundle:
+    owner, repo = parse_github_repository(repository)
+    api_base = f"https://api.github.com/repos/{owner}/{repo}"
+    if release_name == "latest":
+        release_url = f"{api_base}/releases/latest"
+    else:
+        release_url = f"{api_base}/releases/tags/{urllib.parse.quote(release_name, safe='')}"
+    release = fetch_json(release_url)
+    tag = release.get("tag_name")
+    archive_url = release.get("zipball_url")
+    if not isinstance(tag, str) or not isinstance(archive_url, str):
+        raise RuntimeSkillsError("Release metadata is missing tag_name or zipball_url")
+
+    temporary_root = Path(tempfile.mkdtemp(prefix="runtime-skills-release-"))
+    try:
+        archive = temporary_root / "release.zip"
+        extracted = temporary_root / "extracted"
+        extracted.mkdir()
+        download(archive_url, archive)
+        root = extract_zip_safely(archive, extracted)
+        manifest = load_manifest(root)
+        expected_tag = f"v{manifest['release_version']}"
+        if tag != expected_tag:
+            raise RuntimeSkillsError(
+                f"Release tag {tag!r} does not match manifest release {expected_tag!r}"
+            )
+        commit_metadata = fetch_json(f"{api_base}/commits/{urllib.parse.quote(tag, safe='')}")
+        commit = commit_metadata.get("sha")
+        return SourceBundle(
+            root=root,
+            manifest=manifest,
+            ref=tag,
+            commit=commit if isinstance(commit, str) else None,
+            temporary_root=temporary_root,
+        )
+    except Exception:
+        shutil.rmtree(temporary_root, ignore_errors=True)
+        raise
+
+
+def local_source(root: Path) -> SourceBundle:
+    root = root.resolve()
+    manifest = load_manifest(root)
+    branch = git_value(root, "branch", "--show-current")
+    return SourceBundle(
+        root=root,
+        manifest=manifest,
+        ref=branch or "working-tree",
+        commit=git_value(root, "rev-parse", "HEAD"),
+    )
+
+
+@contextmanager
+def source_bundle(
+    *,
+    source: str | None,
+    release: str | None,
+    repository: str | None,
+    lock: dict[str, Any] | None,
+    script_path: Path,
+    default_remote: bool,
+) -> Iterator[SourceBundle]:
+    if source and release:
+        raise RuntimeSkillsError("Use either --source or --release, not both")
+
+    bundle: SourceBundle
+    if source:
+        bundle = local_source(Path(source))
+    elif release or default_remote:
+        repository_url = repository
+        if not repository_url and lock:
+            repository_url = lock.get("source", {}).get("repository")
+        if not repository_url:
+            local_root = locate_local_source(script_path)
+            if local_root:
+                repository_url = load_manifest(local_root)["repository"]["url"]
+        if not repository_url:
+            raise RuntimeSkillsError("--repository is required when no source manifest or lock is available")
+        bundle = remote_source(str(repository_url), release or "latest")
+    else:
+        local_root = locate_local_source(script_path)
+        if not local_root:
+            raise RuntimeSkillsError("No local source found; use --release latest --repository <url>")
+        bundle = local_source(local_root)
+    try:
+        yield bundle
+    finally:
+        bundle.close()
+
+
+def load_lock(project: Path) -> dict[str, Any]:
+    lock = read_json(project / LOCK_NAME)
+    if lock.get("schema_version") != SUPPORTED_SCHEMA_VERSION:
+        raise RuntimeSkillsError(
+            f"Unsupported lock schema: {lock.get('schema_version')!r}; refresh the sync tool"
+        )
+    if not isinstance(lock.get("skills"), dict) or not lock["skills"]:
+        raise RuntimeSkillsError("Lock file contains no installed skills")
+    return lock
+
+
+def lock_drift(project: Path, lock: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    for name, record in sorted(lock["skills"].items()):
+        expected = record.get("content_sha256")
+        destinations = record.get("destinations")
+        if not isinstance(destinations, list) or not destinations:
+            problems.append(f"{name}: no destinations recorded")
+            continue
+        for relative in destinations:
+            destination = safe_project_path(project, str(relative))
+            if not destination.is_dir():
+                problems.append(f"{name}: missing {relative}")
+                continue
+            actual = content_hash(destination)
+            if actual != expected:
+                problems.append(f"{name}: locally modified or mixed version at {relative}")
+
+    installer = lock.get("tool", {})
+    installer_path = installer.get("path", INSTALLED_TOOL_PATH)
+    expected_tool_hash = installer.get("content_sha256")
+    tool_path = safe_project_path(project, str(installer_path))
+    if not tool_path.is_file():
+        problems.append(f"sync tool: missing {installer_path}")
+    elif expected_tool_hash and file_hash(tool_path) != expected_tool_hash:
+        problems.append(f"sync tool: locally modified at {installer_path}")
+    return problems
+
+
+def source_versions(bundle: SourceBundle, installed_names: Sequence[str]) -> dict[str, str]:
+    available = bundle.manifest["skills"]
+    missing = sorted(set(installed_names) - set(available))
+    if missing:
+        raise RuntimeSkillsError("Source release removed installed skills: " + ", ".join(missing))
+    return {name: str(available[name]["version"]) for name in installed_names}
+
+
+def changes_against_source(
+    lock: dict[str, Any], bundle: SourceBundle
+) -> dict[str, str]:
+    changes: dict[str, str] = {}
+    for name, record in sorted(lock["skills"].items()):
+        new_version = str(bundle.manifest["skills"][name]["version"])
+        changes[name] = version_change(str(record["version"]), new_version)
+    changes["sync-tool"] = version_change(
+        str(lock.get("tool", {}).get("version", "0.0.0")),
+        str(bundle.manifest["tool"]["version"]),
+    )
+    return changes
+
+
+def highest_change(changes: dict[str, str]) -> str:
+    order = {"none": 0, "patch": 1, "minor": 2, "major": 3, "downgrade": 4}
+    return max(changes.values(), key=lambda value: order[value], default="none")
+
+
+def copy_to_stage(source: Path, destination: Path) -> None:
+    if source.is_dir():
+        shutil.copytree(source, destination)
+    elif source.is_file():
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+    else:
+        raise RuntimeSkillsError(f"Deployment source is missing: {source}")
+
+
+def deploy_transaction(project: Path, operations: list[tuple[Path, Path]]) -> None:
+    if not operations:
+        return
+    transaction_root = Path(
+        tempfile.mkdtemp(prefix=".runtime-skills-transaction-", dir=project)
+    )
+    staged_root = transaction_root / "staged"
+    backup_root = transaction_root / "backup"
+    staged_root.mkdir()
+    backup_root.mkdir()
+    staged: list[tuple[Path, Path, Path]] = []
+    installed: list[tuple[Path, Path | None]] = []
+    try:
+        for index, (source, destination) in enumerate(operations):
+            staged_path = staged_root / str(index)
+            copy_to_stage(source, staged_path)
+            staged.append((staged_path, destination, backup_root / str(index)))
+
+        for staged_path, destination, backup in staged:
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            previous: Path | None = None
+            if destination.exists():
+                os.replace(destination, backup)
+                previous = backup
+            try:
+                os.replace(staged_path, destination)
+            except Exception:
+                if previous and previous.exists():
+                    os.replace(previous, destination)
+                raise
+            installed.append((destination, previous))
+    except Exception:
+        for destination, previous in reversed(installed):
+            if destination.is_dir():
+                shutil.rmtree(destination, ignore_errors=True)
+            elif destination.exists():
+                destination.unlink()
+            if previous and previous.exists():
+                os.replace(previous, destination)
+        raise
+    finally:
+        shutil.rmtree(transaction_root, ignore_errors=True)
+
+
+def build_lock(
+    project: Path,
+    bundle: SourceBundle,
+    destinations: dict[str, list[str]],
+    previous: dict[str, Any] | None,
+    auto_update: str,
+) -> dict[str, Any]:
+    now = utc_now()
+    manifest = bundle.manifest
+    records: dict[str, Any] = {}
+    for name, relative_destinations in sorted(destinations.items()):
+        source_record = manifest["skills"][name]
+        source_directory = bundle.root / source_record["path"]
+        records[name] = {
+            "version": source_record["version"],
+            "destinations": sorted(dict.fromkeys(relative_destinations)),
+            "content_sha256": content_hash(source_directory),
+        }
+
+    tool_path = bundle.root / manifest["tool"]["path"]
+    return {
+        "schema_version": SUPPORTED_SCHEMA_VERSION,
+        "source": {
+            "repository": manifest["repository"]["url"],
+            "release": bundle.ref,
+            "commit": bundle.commit,
+        },
+        "tool": {
+            "version": manifest["tool"]["version"],
+            "path": INSTALLED_TOOL_PATH,
+            "content_sha256": file_hash(tool_path),
+        },
+        "policy": {
+            "check": "first_skill_use_per_session",
+            "auto_update": auto_update,
+        },
+        "phase_pin": (
+            previous.get("phase_pin", {"active": False, "reason": None, "set_at": None})
+            if previous
+            else {"active": False, "reason": None, "set_at": None}
+        ),
+        "skills": records,
+        "installed_at": previous.get("installed_at", now) if previous else now,
+        "updated_at": now,
+    }
+
+
+def prepare_deployment(
+    project: Path,
+    bundle: SourceBundle,
+    destinations: dict[str, list[str]],
+    lock: dict[str, Any],
+) -> tuple[list[tuple[Path, Path]], Path]:
+    operations: list[tuple[Path, Path]] = []
+    for name, relative_destinations in sorted(destinations.items()):
+        source_directory = bundle.root / bundle.manifest["skills"][name]["path"]
+        for relative in relative_destinations:
+            operations.append((source_directory, safe_project_path(project, relative)))
+
+    source_tool = bundle.root / bundle.manifest["tool"]["path"]
+    operations.append((source_tool, safe_project_path(project, INSTALLED_TOOL_PATH)))
+
+    lock_source_dir = Path(tempfile.mkdtemp(prefix="runtime-skills-lock-"))
+    lock_source = lock_source_dir / LOCK_NAME
+    lock_source.write_text(
+        json.dumps(lock, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    operations.append((lock_source, project / LOCK_NAME))
+    return operations, lock_source_dir
+
+
+def deploy_bundle(
+    project: Path,
+    bundle: SourceBundle,
+    destinations: dict[str, list[str]],
+    previous: dict[str, Any] | None,
+    auto_update: str,
+) -> dict[str, Any]:
+    lock = build_lock(project, bundle, destinations, previous, auto_update)
+    operations, temporary_lock_dir = prepare_deployment(project, bundle, destinations, lock)
+    try:
+        deploy_transaction(project, operations)
+    finally:
+        shutil.rmtree(temporary_lock_dir, ignore_errors=True)
+    return lock
+
+
+def normalize_destination(skill_root: str, skill_name: str) -> str:
+    root = Path(skill_root)
+    if root.is_absolute() or ".." in root.parts:
+        raise RuntimeSkillsError(f"Destination roots must be relative: {skill_root!r}")
+    return (root / skill_name).as_posix()
+
+
+def command_install(args: argparse.Namespace, script_path: Path) -> int:
+    project = Path(args.project).resolve()
+    project.mkdir(parents=True, exist_ok=True)
+    previous = load_lock(project) if (project / LOCK_NAME).is_file() else None
+    if previous:
+        if previous.get("phase_pin", {}).get("active"):
+            raise RuntimeSkillsError(
+                "Cannot add or reinstall Skills while an active phase is pinned"
+            )
+        drift = lock_drift(project, previous)
+        if drift and not args.overwrite_local_changes:
+            raise RuntimeSkillsError(
+                "Refusing to overwrite local changes:\n- " + "\n- ".join(drift)
+            )
+
+    with source_bundle(
+        source=args.source,
+        release=args.release,
+        repository=args.repository,
+        lock=previous,
+        script_path=script_path,
+        default_remote=False,
+    ) as bundle:
+        requested = list(dict.fromkeys(args.skill))
+        unknown = sorted(set(requested) - set(bundle.manifest["skills"]))
+        if unknown:
+            raise RuntimeSkillsError("Unknown skills: " + ", ".join(unknown))
+        if previous:
+            source_versions(bundle, list(previous["skills"]))
+            existing_changes = changes_against_source(previous, bundle)
+            existing_level = highest_change(existing_changes)
+            if existing_level == "downgrade":
+                raise RuntimeSkillsError("Refusing to downgrade installed Skills while adding a Skill")
+            if existing_level in {"minor", "major"}:
+                raise RuntimeSkillsError(
+                    f"Existing Skills require a {existing_level} update; run update with explicit "
+                    f"--allow {existing_level} before adding another Skill"
+                )
+
+        destinations: dict[str, list[str]] = {}
+        if previous:
+            destinations.update(
+                {
+                    name: list(record["destinations"])
+                    for name, record in previous["skills"].items()
+                }
+            )
+        for name in requested:
+            new_destinations = [
+                normalize_destination(root, name) for root in args.destination
+            ]
+            destinations[name] = sorted(
+                set(destinations.get(name, [])) | set(new_destinations)
+            )
+
+        unmanaged_conflicts: list[str] = []
+        for name, relative_destinations in destinations.items():
+            if name not in bundle.manifest["skills"]:
+                raise RuntimeSkillsError(f"Installed skill is missing from source: {name}")
+            for relative in relative_destinations:
+                destination = safe_project_path(project, relative)
+                if destination.exists() and not previous and not args.overwrite_local_changes:
+                    if not destination.is_dir():
+                        unmanaged_conflicts.append(f"{relative}: existing path is not a directory")
+                        continue
+                    current = file_inventory(destination)
+                    incoming = source_inventory(bundle, name)
+                    added, modified, removed = inventory_changes(current, incoming)
+                    unmanaged_conflicts.append(f"{relative}: unmanaged existing Skill")
+                    for label, paths in (
+                        ("incoming adds", added),
+                        ("incoming modifies", modified),
+                        ("incoming removes", removed),
+                    ):
+                        for path in paths:
+                            unmanaged_conflicts.append(f"  {label}: {path}")
+                    if not added and not modified and not removed:
+                        unmanaged_conflicts.append("  content already matches the selected source")
+        if unmanaged_conflicts:
+            raise RuntimeSkillsError(
+                "Unmanaged Skill directories already exist. Review this comparison, then rerun "
+                "with --overwrite-local-changes to adopt the selected Release:\n- "
+                + "\n- ".join(unmanaged_conflicts)
+            )
+
+        lock = deploy_bundle(
+            project,
+            bundle,
+            destinations,
+            previous,
+            args.auto_update if not previous else previous["policy"]["auto_update"],
+        )
+    print(
+        f"Installed {len(lock['skills'])} skill(s) from {lock['source']['release']} "
+        f"and wrote {LOCK_NAME}."
+    )
+    return 0
+
+
+def command_verify(args: argparse.Namespace) -> int:
+    project = Path(args.project).resolve()
+    lock = load_lock(project)
+    drift = lock_drift(project, lock)
+    if drift:
+        print("Verification failed:")
+        for problem in drift:
+            print(f"- {problem}")
+        return 2
+    print(
+        f"Verified {len(lock['skills'])} skill(s) at {lock['source']['release']}; "
+        "all managed copies match the lock."
+    )
+    return 0
+
+
+def print_version_status(lock: dict[str, Any], bundle: SourceBundle) -> dict[str, str]:
+    source_versions(bundle, list(lock["skills"]))
+    changes = changes_against_source(lock, bundle)
+    for name, change in changes.items():
+        if name == "sync-tool":
+            old = str(lock.get("tool", {}).get("version", "0.0.0"))
+            new = str(bundle.manifest["tool"]["version"])
+        else:
+            old = str(lock["skills"][name]["version"])
+            new = str(bundle.manifest["skills"][name]["version"])
+        print(f"- {name}: {old} -> {new} ({change})")
+    return changes
+
+
+def command_status(args: argparse.Namespace, script_path: Path) -> int:
+    project = Path(args.project).resolve()
+    lock = load_lock(project)
+    drift = lock_drift(project, lock)
+    if drift:
+        print("Local status: attention required")
+        for problem in drift:
+            print(f"- {problem}")
+        return 2
+    print(
+        f"Local status: ready; {len(lock['skills'])} skill(s) match "
+        f"{lock['source']['release']}."
+    )
+    pin = lock.get("phase_pin", {})
+    if pin.get("active"):
+        print(f"Phase pin: active ({pin.get('reason') or 'no reason recorded'})")
+    else:
+        print("Phase pin: inactive")
+
+    if not args.check_remote:
+        return 0
+    try:
+        with source_bundle(
+            source=None,
+            release="latest",
+            repository=args.repository,
+            lock=lock,
+            script_path=script_path,
+            default_remote=True,
+        ) as bundle:
+            print(f"Latest stable release: {bundle.ref}")
+            changes = print_version_status(lock, bundle)
+    except RuntimeSkillsError as exc:
+        print(f"Remote status: unavailable ({exc})")
+        return 0
+    return 10 if highest_change(changes) != "none" else 0
+
+
+def source_inventory(bundle: SourceBundle, skill_name: str) -> dict[str, str]:
+    record = bundle.manifest["skills"][skill_name]
+    return file_inventory(bundle.root / record["path"])
+
+
+def inventory_changes(
+    current: dict[str, str], incoming: dict[str, str]
+) -> tuple[list[str], list[str], list[str]]:
+    added = sorted(set(incoming) - set(current))
+    removed = sorted(set(current) - set(incoming))
+    modified = sorted(
+        path for path in set(current) & set(incoming) if current[path] != incoming[path]
+    )
+    return added, modified, removed
+
+
+def command_diff(args: argparse.Namespace, script_path: Path) -> int:
+    project = Path(args.project).resolve()
+    lock = load_lock(project)
+    with source_bundle(
+        source=args.source,
+        release=args.release,
+        repository=args.repository,
+        lock=lock,
+        script_path=script_path,
+        default_remote=not bool(args.source),
+    ) as bundle:
+        source_versions(bundle, list(lock["skills"]))
+        print(f"Comparing {lock['source']['release']} with {bundle.ref}:")
+        for name, record in sorted(lock["skills"].items()):
+            destination = safe_project_path(project, record["destinations"][0])
+            current = file_inventory(destination) if destination.is_dir() else {}
+            incoming = source_inventory(bundle, name)
+            added, modified, removed = inventory_changes(current, incoming)
+            old_version = record["version"]
+            new_version = bundle.manifest["skills"][name]["version"]
+            print(f"- {name}: {old_version} -> {new_version}")
+            for label, paths in (("added", added), ("modified", modified), ("removed", removed)):
+                for path in paths:
+                    print(f"  {label}: {path}")
+            if not added and not removed and not modified:
+                print("  no content changes")
+    return 0
+
+
+def update_from_bundle(
+    args: argparse.Namespace,
+    script_path: Path,
+    *,
+    automatic: bool,
+) -> int:
+    project = Path(args.project).resolve()
+    lock = load_lock(project)
+    pin = lock.get("phase_pin", {})
+    if pin.get("active") and not getattr(args, "ignore_pin", False):
+        reason = pin.get("reason") or "no reason recorded"
+        raise RuntimeSkillsError(f"Update deferred because the active phase is pinned: {reason}")
+
+    drift = lock_drift(project, lock)
+    if drift and not getattr(args, "overwrite_local_changes", False):
+        raise RuntimeSkillsError(
+            "Refusing to overwrite local changes:\n- " + "\n- ".join(drift)
+        )
+
+    requested_source = getattr(args, "source", None)
+    requested_release = None if requested_source else (getattr(args, "release", None) or "latest")
+    with source_bundle(
+        source=requested_source,
+        release=requested_release,
+        repository=getattr(args, "repository", None),
+        lock=lock,
+        script_path=script_path,
+        default_remote=True,
+    ) as bundle:
+        source_versions(bundle, list(lock["skills"]))
+        changes = changes_against_source(lock, bundle)
+        level = highest_change(changes)
+        if level == "downgrade":
+            raise RuntimeSkillsError("Refusing to downgrade an installed Skill or sync tool")
+        if level == "none":
+            print(f"Already current at {bundle.ref}.")
+            return 0
+
+        allowed = "patch" if automatic else getattr(args, "allow", "major")
+        order = {"none": 0, "patch": 1, "minor": 2, "major": 3}
+        if order[level] > order[allowed]:
+            print_version_status(lock, bundle)
+            raise RuntimeSkillsError(
+                f"The update contains a {level} change; explicit --allow {level} or higher is required"
+            )
+
+        destinations = {
+            name: list(record["destinations"])
+            for name, record in lock["skills"].items()
+        }
+        updated = deploy_bundle(
+            project,
+            bundle,
+            destinations,
+            lock,
+            lock["policy"]["auto_update"],
+        )
+    print(f"Updated {len(updated['skills'])} skill(s) to {updated['source']['release']}.")
+    return 0
+
+
+def command_sync(args: argparse.Namespace, script_path: Path) -> int:
+    project = Path(args.project).resolve()
+    lock = load_lock(project)
+    drift = lock_drift(project, lock)
+    if drift:
+        print("Automatic synchronization stopped because local drift was detected:")
+        for problem in drift:
+            print(f"- {problem}")
+        return 2
+    if lock.get("phase_pin", {}).get("active"):
+        print(
+            "Automatic synchronization deferred by the active phase pin: "
+            f"{lock['phase_pin'].get('reason') or 'no reason recorded'}"
+        )
+        return 0
+    if lock.get("policy", {}).get("auto_update") != "patch":
+        print("Automatic updates are disabled; local copies are verified.")
+        return command_status(
+            argparse.Namespace(
+                project=args.project,
+                check_remote=True,
+                repository=args.repository,
+            ),
+            script_path,
+        )
+    try:
+        return update_from_bundle(args, script_path, automatic=True)
+    except RuntimeSkillsError as exc:
+        if "explicit --allow" in str(exc):
+            print(f"Automatic synchronization needs user confirmation: {exc}")
+            return 10
+        if "Unable to" in str(exc):
+            print(f"Remote update check unavailable; verified local copies remain usable: {exc}")
+            return 0
+        raise
+
+
+def command_pin(args: argparse.Namespace) -> int:
+    project = Path(args.project).resolve()
+    lock = load_lock(project)
+    lock["phase_pin"] = {
+        "active": True,
+        "reason": args.reason,
+        "set_at": utc_now(),
+    }
+    lock["updated_at"] = utc_now()
+    write_json_atomic(project / LOCK_NAME, lock)
+    print(f"Pinned Runtime Skills for the active phase: {args.reason}")
+    return 0
+
+
+def command_unpin(args: argparse.Namespace) -> int:
+    project = Path(args.project).resolve()
+    lock = load_lock(project)
+    lock["phase_pin"] = {"active": False, "reason": None, "set_at": None}
+    lock["updated_at"] = utc_now()
+    write_json_atomic(project / LOCK_NAME, lock)
+    print("Removed the active phase pin.")
+    return 0
+
+
+def add_source_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--source", help="Local dev-runtime-skill checkout")
+    parser.add_argument(
+        "--release",
+        help="GitHub Release tag or 'latest'; defaults to latest for update/diff/sync",
+    )
+    parser.add_argument("--repository", help="Override the GitHub repository URL")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Install and synchronize versioned Runtime Skills."
+    )
+    parser.add_argument("--version", action="version", version=TOOL_VERSION)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    install = subparsers.add_parser("install", help="Install or add managed Skills")
+    install.add_argument("--project", required=True, help="Target project root")
+    install.add_argument("--skill", action="append", required=True, help="Skill name; repeatable")
+    install.add_argument(
+        "--destination",
+        action="append",
+        required=True,
+        help="Project-relative Skill root such as .agents/skills; repeatable",
+    )
+    install.add_argument(
+        "--auto-update", choices=["none", "patch"], default="patch"
+    )
+    install.add_argument("--overwrite-local-changes", action="store_true")
+    add_source_arguments(install)
+
+    verify = subparsers.add_parser("verify", help="Verify installed copies against the lock")
+    verify.add_argument("--project", default=".")
+
+    status = subparsers.add_parser("status", help="Show local and optional remote status")
+    status.add_argument("--project", default=".")
+    status.add_argument("--check-remote", action="store_true")
+    status.add_argument("--repository")
+
+    diff = subparsers.add_parser("diff", help="List incoming Skill file changes")
+    diff.add_argument("--project", default=".")
+    add_source_arguments(diff)
+
+    update = subparsers.add_parser("update", help="Update all managed copies as one bundle")
+    update.add_argument("--project", default=".")
+    update.add_argument("--allow", choices=["patch", "minor", "major"], default="patch")
+    update.add_argument("--ignore-pin", action="store_true")
+    update.add_argument("--overwrite-local-changes", action="store_true")
+    add_source_arguments(update)
+
+    sync = subparsers.add_parser(
+        "sync", help="Verify and automatically apply compatible patch updates"
+    )
+    sync.add_argument("--project", default=".")
+    add_source_arguments(sync)
+    sync.set_defaults(ignore_pin=False, overwrite_local_changes=False)
+
+    pin = subparsers.add_parser("pin", help="Freeze installed versions for an active phase")
+    pin.add_argument("--project", default=".")
+    pin.add_argument("--reason", required=True)
+
+    unpin = subparsers.add_parser("unpin", help="Remove the active phase freeze")
+    unpin.add_argument("--project", default=".")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    script_path = Path(__file__).resolve()
+    try:
+        if args.command == "install":
+            return command_install(args, script_path)
+        if args.command == "verify":
+            return command_verify(args)
+        if args.command == "status":
+            return command_status(args, script_path)
+        if args.command == "diff":
+            return command_diff(args, script_path)
+        if args.command == "update":
+            return update_from_bundle(args, script_path, automatic=False)
+        if args.command == "sync":
+            return command_sync(args, script_path)
+        if args.command == "pin":
+            return command_pin(args)
+        if args.command == "unpin":
+            return command_unpin(args)
+        parser.error(f"Unknown command: {args.command}")
+    except RuntimeSkillsError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-skill-manifest.py
+++ b/scripts/validate-skill-manifest.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Validate the Runtime Skills manifest and required version bumps."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_runtime_module(root: Path) -> Any:
+    script = root / "scripts/runtime-skills.py"
+    spec = importlib.util.spec_from_file_location("runtime_skills", script)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to import {script}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def parse_frontmatter(path: Path) -> dict[str, str]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0].strip() != "---":
+        raise RuntimeError(f"{path} has no YAML frontmatter")
+    metadata: dict[str, str] = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return metadata
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        match = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
+        if match:
+            metadata[match.group(1)] = match.group(2).strip()
+    raise RuntimeError(f"{path} has unterminated YAML frontmatter")
+
+
+def manifest_at_ref(root: Path, ref: str) -> dict[str, Any] | None:
+    try:
+        payload = run_git(root, "show", f"{ref}:skills-manifest.json")
+    except subprocess.CalledProcessError:
+        return None
+    return json.loads(payload)
+
+
+def changed_paths(root: Path, ref: str) -> list[str]:
+    output = run_git(root, "diff", "--name-only", f"{ref}...HEAD")
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def validate_repository(root: Path, compare_ref: str | None, release_tag: str | None) -> list[str]:
+    runtime = load_runtime_module(root)
+    manifest = runtime.read_json(root / runtime.MANIFEST_NAME)
+    errors = runtime.validate_manifest(manifest, root)
+
+    if manifest.get("tool", {}).get("version") != runtime.TOOL_VERSION:
+        errors.append(
+            "manifest tool.version must match TOOL_VERSION in scripts/runtime-skills.py"
+        )
+
+    manifest_skills = set(manifest.get("skills", {}))
+    directory_skills = {
+        path.parent.name for path in (root / "skills").glob("*/SKILL.md")
+    }
+    if manifest_skills != directory_skills:
+        errors.append(
+            "manifest skill set differs from skills/*/SKILL.md: "
+            f"manifest-only={sorted(manifest_skills - directory_skills)}, "
+            f"directory-only={sorted(directory_skills - manifest_skills)}"
+        )
+
+    for name, record in sorted(manifest.get("skills", {}).items()):
+        skill_file = root / record["path"] / "SKILL.md"
+        try:
+            metadata = parse_frontmatter(skill_file)
+        except RuntimeError as exc:
+            errors.append(str(exc))
+            continue
+        if metadata.get("name") != name:
+            errors.append(
+                f"{skill_file}: frontmatter name {metadata.get('name')!r} does not match {name!r}"
+            )
+        unexpected = sorted(set(metadata) - {"name", "description"})
+        if unexpected:
+            errors.append(
+                f"{skill_file}: unsupported frontmatter fields: {', '.join(unexpected)}"
+            )
+
+    if release_tag:
+        expected = f"v{manifest.get('release_version')}"
+        if release_tag != expected:
+            errors.append(f"release tag {release_tag!r} must equal {expected!r}")
+
+    if compare_ref:
+        previous = manifest_at_ref(root, compare_ref)
+        if previous is not None:
+            paths = changed_paths(root, compare_ref)
+            try:
+                if runtime.parse_semver(str(manifest["release_version"])) < runtime.parse_semver(
+                    str(previous["release_version"])
+                ):
+                    errors.append(
+                        "release_version may not decrease: "
+                        f"{previous['release_version']} -> {manifest['release_version']}"
+                    )
+            except runtime.RuntimeSkillsError as exc:
+                errors.append(str(exc))
+            for name, record in sorted(manifest.get("skills", {}).items()):
+                prefix = record["path"].rstrip("/") + "/"
+                if not any(path.startswith(prefix) for path in paths):
+                    continue
+                old_record = previous.get("skills", {}).get(name)
+                if old_record is None:
+                    continue
+                old = str(old_record.get("version", ""))
+                new = str(record.get("version", ""))
+                try:
+                    if runtime.parse_semver(new) <= runtime.parse_semver(old):
+                        errors.append(
+                            f"{name} changed but its version did not increase: {old} -> {new}"
+                        )
+                except runtime.RuntimeSkillsError as exc:
+                    errors.append(str(exc))
+
+            if "scripts/runtime-skills.py" in paths:
+                old = str(previous.get("tool", {}).get("version", ""))
+                new = str(manifest.get("tool", {}).get("version", ""))
+                try:
+                    if runtime.parse_semver(new) <= runtime.parse_semver(old):
+                        errors.append(
+                            f"sync tool changed but tool.version did not increase: {old} -> {new}"
+                        )
+                except runtime.RuntimeSkillsError as exc:
+                    errors.append(str(exc))
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--compare-ref")
+    parser.add_argument("--release-tag")
+    args = parser.parse_args()
+    root = Path(args.root).resolve()
+    try:
+        errors = validate_repository(root, args.compare_ref, args.release_tag)
+    except (RuntimeError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        print(f"validation error: {exc}", file=sys.stderr)
+        return 1
+    if errors:
+        print("Skill manifest validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("Skill manifest validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "release_version": "0.1.0",
+  "repository": {
+    "url": "https://github.com/xinghang-ee-cs/dev-runtime-skill",
+    "channel": "stable"
+  },
+  "tool": {
+    "version": "0.1.0",
+    "path": "scripts/runtime-skills.py"
+  },
+  "skills": {
+    "ai-code-inspection": {
+      "version": "0.1.0",
+      "path": "skills/ai-code-inspection"
+    },
+    "long-task-orchestrator": {
+      "version": "0.1.0",
+      "path": "skills/long-task-orchestrator"
+    },
+    "planning-layer-runtime": {
+      "version": "0.1.0",
+      "path": "skills/planning-layer-runtime"
+    },
+    "testing-layer-runtime": {
+      "version": "0.1.0",
+      "path": "skills/testing-layer-runtime"
+    }
+  }
+}

--- a/src/content/docs/reference/versioning-and-updates.md
+++ b/src/content/docs/reference/versioning-and-updates.md
@@ -1,0 +1,134 @@
+---
+title: 版本与更新机制
+description: Runtime Skills 的版本事实、安装锁、使用前同步、期次锁定和发布规则。
+sidebar:
+  order: 2
+---
+
+## 单一事实源
+
+| 文件或对象 | 职责 | 禁止承担的职责 |
+|---|---|---|
+| `skills-manifest.json` | 当前仓库 Release 版本、同步工具版本、每个 Skill 的独立版本和路径 | 不记录某个目标项目装了什么 |
+| GitHub tag / Release | 固定一组经过验证的仓库快照和人类可读更新记录 | 不表示目标项目已经升级 |
+| 目标项目 `runtime-skills.lock.json` | 记录实际安装 Release、commit、Skill 版本、全部目标位置和内容摘要 | 不定义最新版本 |
+| README 和教程 | 解释安装、更新与版本规则 | 不保存当前版本数字 |
+| `SKILL.md` | Skill 的触发条件、工作流和边界 | 不增加 `version` frontmatter |
+
+`package.json` 只属于 Astro/Starlight 文档站，它的版本不得用于判断 Skill 新旧。
+
+## 安装
+
+从本仓库执行：
+
+```bash
+python scripts/runtime-skills.py install \
+  --release latest \
+  --project /path/to/project \
+  --skill planning-layer-runtime \
+  --destination .agents/skills
+```
+
+需要同时支持 Claude Code 时，再传入 `--destination .claude/skills`。所有副本写入同一个锁文件；后续更新始终把已安装 Skill 作为一个 Release 快照共同处理，不允许只更新其中一个平台副本。
+
+`--release latest` 是普通用户的稳定入口。维护者需要验证尚未发布的本地内容时，才使用 `--source /path/to/dev-runtime-skill`，此时锁文件会记录实际分支和 commit，而不会伪装成 Release。
+
+### 迁移已有的无版本副本
+
+目标目录已经存在但没有 `runtime-skills.lock.json` 时，首次 `install` 不会直接覆盖。工具会列出发布版相对旧副本将新增、修改和删除的文件。用户确认愿意采用发布版后，再运行同一安装命令并增加：
+
+```bash
+--overwrite-local-changes
+```
+
+工具随后统一替换所有目标副本、安装项目内同步入口并生成锁文件。目标项目原有 `AGENTS.md` 或 `CLAUDE.md` 仍由 Agent 合并适用规则，不能整体覆盖。
+
+## 使用前同步
+
+目标项目中的入口为：
+
+```bash
+python .runtime-skills/runtime-skills.py sync --project .
+```
+
+每个 Agent 会话第一次使用任一 Runtime Skill 前执行一次。同一会话中，锁文件没有变化时不重复执行。
+
+`sync` 的判断顺序：
+
+1. 校验所有安装目录和同步工具是否匹配锁文件摘要。
+2. 如果存在本地修改或平台间漂移，停止覆盖。
+3. 如果存在活动期次锁定，只验证当前版本，不远端更新。
+4. 查询最新稳定 GitHub Release。
+5. 自动安装兼容的补丁版本。
+6. 次版本或主版本只报告变化，等待明确确认。
+7. 更新成功后一次性替换全部受管副本和锁文件。
+
+远端不可用时，已安装副本全部通过本地校验即可继续使用锁定版本，但 Agent 必须说明没有完成最新版本检查。
+
+## 活动期次锁定
+
+Planning、Long 和 Testing 会共同消费带 revision 的合同与 Runtime 状态。中途升级可能让新规则解释旧状态，因此新期次应先同步，再锁定：
+
+```bash
+python .runtime-skills/runtime-skills.py sync --project .
+python .runtime-skills/runtime-skills.py pin --project . --reason phase-01
+```
+
+保持该锁直到期次关闭：
+
+```bash
+python .runtime-skills/runtime-skills.py unpin --project .
+```
+
+如必须中途迁移，先让用户确认，再解除锁定、查看差异、升级，并重新验证受影响的 Planning Baseline、Handoff 和 Runtime 状态。
+
+## 手动检查和升级
+
+```bash
+# 只校验本地副本
+python .runtime-skills/runtime-skills.py verify --project .
+
+# 校验并检查最新 Release
+python .runtime-skills/runtime-skills.py status --project . --check-remote
+
+# 列出即将新增、修改和删除的文件
+python .runtime-skills/runtime-skills.py diff --project . --release latest
+
+# 明确接受次版本更新
+python .runtime-skills/runtime-skills.py update --project . --release latest --allow minor
+
+# 明确接受主版本更新
+python .runtime-skills/runtime-skills.py update --project . --release latest --allow major
+```
+
+检测到本地修改时，先执行 `diff`。只有用户明确决定放弃本地修改后，才可使用 `--overwrite-local-changes`；不得由 Agent 自行推断。
+
+常用返回码：
+
+| 返回码 | 含义 |
+|---|---|
+| `0` | 本地版本可用；也可能是远端暂时不可用但本地校验通过 |
+| `1` | 命令参数、版本门禁、期次锁定或来源校验失败 |
+| `2` | 检测到文件缺失、本地修改或多平台副本漂移 |
+| `10` | 检测到更新，但需要用户确认次版本或主版本变化 |
+
+## 版本升级口径
+
+| 级别 | 适用变化 |
+|---|---|
+| PATCH | 表达修正、缺陷修复，以及不改变持久化结构、输出合同、门禁或交接兼容性的调整 |
+| MINOR | 向后兼容的新能力、新可选字段或新工作流分支 |
+| MAJOR | Runtime 文件结构、状态枚举、门禁、安装布局或跨 Skill 交接合同的破坏性变化 |
+
+每次修改 `skills/<name>/`，必须同时提升清单中该 Skill 的版本。修改同步工具时必须提升工具版本。CI 会阻止内容已变化但版本未提升的 PR。
+
+## 发布
+
+1. 修改受影响的 Skill 或同步工具版本。
+2. 确认 `skills-manifest.json` 的 `release_version` 是本次仓库 Release 版本。
+3. 通过清单校验和同步工具测试。
+4. 合并发布变更。
+5. 创建与清单完全一致的 tag，例如 `v0.2.0`。
+6. tag workflow 再次校验并自动创建 GitHub Release 和 Release Notes。
+
+Release 是稳定使用入口。`main` 可以包含尚未发布的下一版内容，但目标项目的自动同步只消费 GitHub Release，不直接追随移动的 `main`。

--- a/src/content/docs/tutorials/getting-started.md
+++ b/src/content/docs/tutorials/getting-started.md
@@ -1,28 +1,44 @@
 ---
 title: 安装 Runtime Skills
-description: 把 Runtime Skills 完整部署到一个 Codex 项目中。
+description: 使用版本锁和同步工具，把 Runtime Skills 部署到一个或多个 Agent 平台。
 sidebar:
   order: 1
 ---
 
 ## 准备条件
 
-目标项目应当能够被 Codex 打开，并允许在项目根目录维护 `AGENTS.md` 和 `skills/`。
+目标项目应当能被所选 Agent 打开，并允许在项目根目录维护 Agent 指令、Skill 目录和 `runtime-skills.lock.json`。执行安装的 Agent 还需要读取本仓库并运行 Python 3 标准库脚本。
 
-## 1. 复制完整目录
+## 1. 运行受管安装
 
-复制仓库中的整个 `skills/` 目录。不要只复制入口 `SKILL.md`，因为运行时会按任务需要读取 references、模板和 agent 元数据。
+不要手工复制整个 `skills/`。从本仓库运行同步工具，明确选择 Skill 和每个 Agent 平台的目标根目录：
+
+```bash
+python scripts/runtime-skills.py install \
+  --release latest \
+  --project /path/to/your-project \
+  --skill planning-layer-runtime \
+  --skill long-task-orchestrator \
+  --destination .agents/skills \
+  --destination .claude/skills
+```
+
+同步工具复制完整 Skill 包，不会漏掉 references、模板和 agent 元数据。多次提供 `--skill` 和 `--destination` 即可安装多个 Skill 和平台。
 
 ```text
 your-project/
   AGENTS.md
+  runtime-skills.lock.json
+  .runtime-skills/
+    runtime-skills.py
   .runtime/
     ai-code-inspection/        # 首次使用时按需初始化，不从其他项目复制
-  skills/
-    ai-code-inspection/
+  .agents/skills/
     planning-layer-runtime/
     long-task-orchestrator/
-    testing-layer-runtime/
+  .claude/skills/
+    planning-layer-runtime/
+    long-task-orchestrator/
 ```
 
 ## 2. 添加项目路由
@@ -31,34 +47,39 @@ your-project/
 
 | 任务意图 | 应读取的入口 |
 |---|---|
-| 开发前的需求和方案规划 | `skills/planning-layer-runtime/SKILL.md` |
-| 执行已确认的完整开发任务 | `skills/long-task-orchestrator/SKILL.md` |
-| 人工、设备、云端和最终验收 | `skills/testing-layer-runtime/SKILL.md` |
-| 检查当前代码改动 | `skills/ai-code-inspection/SKILL.md` |
+| 开发前的需求和方案规划 | 已安装的 `planning-layer-runtime/SKILL.md` |
+| 执行已确认的完整开发任务 | 已安装的 `long-task-orchestrator/SKILL.md` |
+| 人工、设备、云端和最终验收 | 已安装的 `testing-layer-runtime/SKILL.md` |
+| 检查当前代码改动 | 已安装的 `ai-code-inspection/SKILL.md` |
 
 项目自己的命令、账号边界、环境事实和发布流程应继续写在项目文档中，不要回填进通用 Skill。
 
 ## 3. 让首次运行发现项目事实
 
-第一次运行 `ai-code-inspection` 时，Codex 从 `skills/ai-code-inspection/assets/runtime-templates/` 初始化项目根目录 `.runtime/ai-code-inspection/`，再检查目标仓库的真实组件、语言、框架、包管理器、脚本、持久化、契约和 CI 配置，填写稳定环境事实。
+第一次运行 `ai-code-inspection` 时，Agent 从已安装的 `ai-code-inspection/assets/runtime-templates/` 初始化项目根目录 `.runtime/ai-code-inspection/`，再检查目标仓库的真实组件、语言、框架、包管理器、脚本、持久化、契约和 CI 配置，填写稳定环境事实。
 
 只有无法从仓库可靠判断的信息才需要询问。不要从另一个项目复制环境结论。
 
-## 4. 验证部署
+## 4. 验证部署与版本
 
-确认以下文件存在：
+首先运行：
+
+```bash
+python .runtime-skills/runtime-skills.py verify --project .
+```
+
+确认锁文件、同步工具和所选 Skill 的完整路径存在，例如：
 
 ```text
 AGENTS.md
-skills/ai-code-inspection/SKILL.md
-skills/ai-code-inspection/assets/runtime-templates/project-environment-profile.md
-skills/ai-code-inspection/assets/runtime-templates/inspection-runtime-state.md
-skills/planning-layer-runtime/SKILL.md
-skills/long-task-orchestrator/SKILL.md
-skills/testing-layer-runtime/SKILL.md
+runtime-skills.lock.json
+.runtime-skills/runtime-skills.py
+.agents/skills/planning-layer-runtime/SKILL.md
 ```
 
 然后给 Codex 一个示例任务，让它只回答“应该使用哪个 Skill，以及为什么”。如果路由和边界正确，再进入真实任务。
+
+每个新会话第一次使用 Runtime Skill 前运行 `sync`。新期次开始前同步并执行 `pin --reason <期次标识>`；期次关闭后执行 `unpin`。详细规则见[版本与更新机制](../../reference/versioning-and-updates/)。
 
 ## 下一步
 

--- a/tests/test_runtime_skills.py
+++ b/tests/test_runtime_skills.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPOSITORY_ROOT / "scripts/runtime-skills.py"
+
+
+def load_runtime_module():
+    spec = importlib.util.spec_from_file_location("runtime_skills_test", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load runtime-skills.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+runtime = load_runtime_module()
+
+
+class RuntimeSkillsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.source = self.root / "source"
+        self.project = self.root / "project"
+        (self.source / "scripts").mkdir(parents=True)
+        shutil.copy2(SCRIPT, self.source / "scripts/runtime-skills.py")
+        self.write_source("0.1.0", "first\n")
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write_source(self, version: str, content: str) -> None:
+        skill = self.source / "skills/example-skill"
+        skill.mkdir(parents=True, exist_ok=True)
+        (skill / "SKILL.md").write_text(
+            "---\nname: example-skill\ndescription: Test fixture.\n---\n\n" + content,
+            encoding="utf-8",
+        )
+        manifest = {
+            "schema_version": 1,
+            "release_version": "0.1.0",
+            "repository": {
+                "url": "https://github.com/example/runtime-skills",
+                "channel": "stable",
+            },
+            "tool": {"version": "0.1.0", "path": "scripts/runtime-skills.py"},
+            "skills": {
+                "example-skill": {
+                    "version": version,
+                    "path": "skills/example-skill",
+                }
+            },
+        }
+        (self.source / "skills-manifest.json").write_text(
+            json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+        )
+
+    def install(self) -> int:
+        return runtime.main(
+            [
+                "install",
+                "--source",
+                str(self.source),
+                "--project",
+                str(self.project),
+                "--skill",
+                "example-skill",
+                "--destination",
+                ".agents/skills",
+                "--destination",
+                ".claude/skills",
+            ]
+        )
+
+    def test_install_and_verify_multiple_destinations(self) -> None:
+        self.assertEqual(self.install(), 0)
+        self.assertTrue((self.project / "runtime-skills.lock.json").is_file())
+        self.assertTrue(
+            (self.project / ".agents/skills/example-skill/SKILL.md").is_file()
+        )
+        self.assertTrue(
+            (self.project / ".claude/skills/example-skill/SKILL.md").is_file()
+        )
+        self.assertTrue(
+            (self.project / ".runtime-skills/runtime-skills.py").is_file()
+        )
+        self.assertEqual(runtime.main(["verify", "--project", str(self.project)]), 0)
+
+    def test_current_repository_bundle_installs_and_verifies(self) -> None:
+        actual_project = self.root / "actual-project"
+        manifest = json.loads(
+            (REPOSITORY_ROOT / "skills-manifest.json").read_text(encoding="utf-8")
+        )
+        arguments = [
+            "install",
+            "--source",
+            str(REPOSITORY_ROOT),
+            "--project",
+            str(actual_project),
+            "--destination",
+            ".agents/skills",
+        ]
+        for name in manifest["skills"]:
+            arguments.extend(["--skill", name])
+        self.assertEqual(runtime.main(arguments), 0)
+        self.assertEqual(
+            runtime.main(["verify", "--project", str(actual_project)]), 0
+        )
+
+    def test_verify_detects_local_drift(self) -> None:
+        self.assertEqual(self.install(), 0)
+        installed = self.project / ".agents/skills/example-skill/SKILL.md"
+        installed.write_text(installed.read_text(encoding="utf-8") + "changed\n", encoding="utf-8")
+        self.assertEqual(runtime.main(["verify", "--project", str(self.project)]), 2)
+
+    def test_unmanaged_existing_copy_requires_explicit_adoption(self) -> None:
+        destination = self.project / ".agents/skills/example-skill"
+        destination.mkdir(parents=True)
+        (destination / "SKILL.md").write_text("old unmanaged copy\n", encoding="utf-8")
+        self.assertEqual(self.install(), 1)
+        self.assertFalse((self.project / "runtime-skills.lock.json").exists())
+
+        result = runtime.main(
+            [
+                "install",
+                "--source",
+                str(self.source),
+                "--project",
+                str(self.project),
+                "--skill",
+                "example-skill",
+                "--destination",
+                ".agents/skills",
+                "--destination",
+                ".claude/skills",
+                "--overwrite-local-changes",
+            ]
+        )
+        self.assertEqual(result, 0)
+        self.assertEqual(runtime.main(["verify", "--project", str(self.project)]), 0)
+
+    def test_patch_update_updates_every_destination(self) -> None:
+        self.assertEqual(self.install(), 0)
+        self.write_source("0.1.1", "second\n")
+        result = runtime.main(
+            [
+                "update",
+                "--source",
+                str(self.source),
+                "--project",
+                str(self.project),
+                "--allow",
+                "patch",
+            ]
+        )
+        self.assertEqual(result, 0)
+        for root in (".agents/skills", ".claude/skills"):
+            content = (self.project / root / "example-skill/SKILL.md").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("second", content)
+        lock = json.loads(
+            (self.project / "runtime-skills.lock.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(lock["skills"]["example-skill"]["version"], "0.1.1")
+        self.assertEqual(runtime.main(["verify", "--project", str(self.project)]), 0)
+
+    def test_sync_automatically_applies_patch_from_selected_source(self) -> None:
+        self.assertEqual(self.install(), 0)
+        self.write_source("0.1.1", "second\n")
+        result = runtime.main(
+            [
+                "sync",
+                "--source",
+                str(self.source),
+                "--project",
+                str(self.project),
+            ]
+        )
+        self.assertEqual(result, 0)
+        content = (
+            self.project / ".agents/skills/example-skill/SKILL.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("second", content)
+
+    def test_active_phase_pin_blocks_update(self) -> None:
+        self.assertEqual(self.install(), 0)
+        self.assertEqual(
+            runtime.main(
+                ["pin", "--project", str(self.project), "--reason", "phase-01"]
+            ),
+            0,
+        )
+        self.write_source("0.1.1", "second\n")
+        result = runtime.main(
+            ["update", "--source", str(self.source), "--project", str(self.project)]
+        )
+        self.assertEqual(result, 1)
+        content = (
+            self.project / ".agents/skills/example-skill/SKILL.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("first", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_skill_manifest.py
+++ b/tests/test_validate_skill_manifest.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ManifestVersionGateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        (self.root / "scripts").mkdir(parents=True)
+        (self.root / "skills/example-skill").mkdir(parents=True)
+        shutil.copy2(
+            REPOSITORY_ROOT / "scripts/runtime-skills.py",
+            self.root / "scripts/runtime-skills.py",
+        )
+        shutil.copy2(
+            REPOSITORY_ROOT / "scripts/validate-skill-manifest.py",
+            self.root / "scripts/validate-skill-manifest.py",
+        )
+        self.write_manifest("0.1.0")
+        self.write_skill("first\n")
+        self.git("init")
+        self.git("config", "user.name", "Runtime Skills Test")
+        self.git("config", "user.email", "runtime-skills@example.invalid")
+        self.git("add", ".")
+        self.git("commit", "-m", "baseline")
+        self.base = self.git("rev-parse", "HEAD").stdout.strip()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", "-C", str(self.root), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def write_skill(self, body: str) -> None:
+        (self.root / "skills/example-skill/SKILL.md").write_text(
+            "---\nname: example-skill\ndescription: Test fixture.\n---\n\n" + body,
+            encoding="utf-8",
+        )
+
+    def write_manifest(self, skill_version: str) -> None:
+        manifest = {
+            "schema_version": 1,
+            "release_version": "0.1.0",
+            "repository": {
+                "url": "https://github.com/example/runtime-skills",
+                "channel": "stable",
+            },
+            "tool": {"version": "0.1.0", "path": "scripts/runtime-skills.py"},
+            "skills": {
+                "example-skill": {
+                    "version": skill_version,
+                    "path": "skills/example-skill",
+                }
+            },
+        }
+        (self.root / "skills-manifest.json").write_text(
+            json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+        )
+
+    def validate(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(self.root / "scripts/validate-skill-manifest.py"),
+                "--root",
+                str(self.root),
+                "--compare-ref",
+                self.base,
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_changed_skill_requires_version_bump(self) -> None:
+        self.write_skill("changed without version bump\n")
+        self.git("add", "skills/example-skill/SKILL.md")
+        self.git("commit", "-m", "change skill without version bump")
+        failed = self.validate()
+        self.assertEqual(failed.returncode, 1)
+        self.assertIn("version did not increase", failed.stderr)
+
+        self.write_manifest("0.1.1")
+        passed = self.validate()
+        self.assertEqual(passed.returncode, 0, passed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #10

## Summary

- add `skills-manifest.json` as the single source of bundle, sync-tool, and per-Skill versions
- add a dependency-free synchronization CLI with `install`, `verify`, `status`, `diff`, `update`, `sync`, `pin`, and `unpin`
- generate a target-project `runtime-skills.lock.json` with Release, commit, destinations, and content hashes
- synchronize multiple Agent platform copies as one bundle and stop on local drift
- auto-apply compatible patch updates while requiring confirmation for minor and major updates
- freeze versions throughout an active Planning → Long → Testing phase
- safely compare and adopt existing unversioned Skill copies
- enforce Skill/tool version bumps in CI and publish validated tag-based GitHub Releases
- update AGENTS rules, Chinese/English README, installation tutorial, and versioning reference

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py'` — 8 tests passed
- `python3 scripts/validate-skill-manifest.py --compare-ref origin/main` — passed
- `python3 scripts/validate-skill-manifest.py --release-tag v0.1.0` — passed
- `git diff --check` — passed
- `node --check astro.config.mjs` — passed
- installed and verified all four current Skills from the real repository manifest

## Local limitation

The complete Astro documentation build was not run locally because this workspace has no `node_modules` and dependency installation was blocked by its network policy. The existing documentation deployment workflow will perform the full Astro build after merge.

## After merge

Create and push tag `v0.1.0`. The new release workflow will validate the tag and manifest, rerun synchronization tests, and create the first GitHub Release with generated notes.