### PR TITLE
fix: automate Runtime Skill releases from main

### DIFF
--- a/.github/workflows/release-skills.yml
+++ b/.github/workflows/release-skills.yml
@@ -2,29 +2,64 @@ name: Release Runtime Skills
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [main]
+    paths:
+      - 'skills/**'
+      - 'scripts/**'
+      - 'tests/**'
+      - 'skills-manifest.json'
+      - '.github/workflows/release-skills.yml'
+  workflow_dispatch:
 
 permissions:
   contents: write
+
+concurrency:
+  group: runtime-skills-release
+  cancel-in-progress: false
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout tagged source
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: main
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Validate release tag and manifest
-        run: python scripts/validate-skill-manifest.py --release-tag "$GITHUB_REF_NAME"
+      - name: Validate manifest
+        run: python scripts/validate-skill-manifest.py
       - name: Test synchronization tool
         run: python -m unittest discover -s tests -p 'test_*.py'
-      - name: Publish GitHub Release
+      - name: Resolve release tag
+        id: release
+        run: |
+          version="$(python -c 'import json; print(json.load(open("skills-manifest.json", encoding="utf-8"))["release_version"])')"
+          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
+      - name: Create release tag when missing
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          git fetch --tags --force
+          if git rev-parse --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Runtime Skills ${TAG}"
+          git push origin "refs/tags/${TAG}"
+      - name: Publish GitHub Release when missing
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes --title "$GITHUB_REF_NAME"
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists."
+            exit 0
+          fi
+          gh release create "$TAG" --verify-tag --generate-notes --title "$TAG"

--- a/scripts/validate-skill-manifest.py
+++ b/scripts/validate-skill-manifest.py
@@ -111,11 +111,20 @@ def validate_repository(root: Path, compare_ref: str | None, release_tag: str | 
         if previous is not None:
             paths = changed_paths(root, compare_ref)
             try:
-                if runtime.parse_semver(str(manifest["release_version"])) < runtime.parse_semver(
-                    str(previous["release_version"])
-                ):
+                current_release = runtime.parse_semver(str(manifest["release_version"]))
+                previous_release = runtime.parse_semver(str(previous["release_version"]))
+                if current_release < previous_release:
                     errors.append(
                         "release_version may not decrease: "
+                        f"{previous['release_version']} -> {manifest['release_version']}"
+                    )
+                managed_content_changed = any(
+                    path.startswith("skills/") or path == "scripts/runtime-skills.py"
+                    for path in paths
+                )
+                if managed_content_changed and current_release <= previous_release:
+                    errors.append(
+                        "managed Skill content changed but release_version did not increase: "
                         f"{previous['release_version']} -> {manifest['release_version']}"
                     )
             except runtime.RuntimeSkillsError as exc:

--- a/src/content/docs/reference/versioning-and-updates.md
+++ b/src/content/docs/reference/versioning-and-updates.md
@@ -120,15 +120,16 @@ python .runtime-skills/runtime-skills.py update --project . --release latest --a
 | MINOR | 向后兼容的新能力、新可选字段或新工作流分支 |
 | MAJOR | Runtime 文件结构、状态枚举、门禁、安装布局或跨 Skill 交接合同的破坏性变化 |
 
-每次修改 `skills/<name>/`，必须同时提升清单中该 Skill 的版本。修改同步工具时必须提升工具版本。CI 会阻止内容已变化但版本未提升的 PR。
+每次修改 `skills/<name>/`，必须同时提升清单中该 Skill 的版本和仓库 `release_version`。修改同步工具时必须提升工具版本和 `release_version`。CI 会阻止内容已变化但对应版本未提升的 PR。
 
 ## 发布
 
-1. 修改受影响的 Skill 或同步工具版本。
-2. 确认 `skills-manifest.json` 的 `release_version` 是本次仓库 Release 版本。
-3. 通过清单校验和同步工具测试。
-4. 合并发布变更。
-5. 创建与清单完全一致的 tag，例如 `v0.2.0`。
-6. tag workflow 再次校验并自动创建 GitHub Release 和 Release Notes。
+1. 修改受影响的 Skill 或同步工具版本，并同步提升 `release_version`。
+2. 通过清单校验和同步工具测试。
+3. 合并发布变更到 `main`。
+4. Release workflow 重新校验 `main`，自动创建与清单一致的 tag，例如 `v0.2.0`。
+5. workflow 自动创建 GitHub Release 和 Release Notes；对应 tag 或 Release 已存在时安全跳过。
+
+不需要维护者在终端手工推送 tag。缺失 Release 时，可以在 GitHub Actions 中手动运行 `Release Runtime Skills` workflow；它仍以最新 `main` 和清单版本为准。
 
 Release 是稳定使用入口。`main` 可以包含尚未发布的下一版内容，但目标项目的自动同步只消费 GitHub Release，不直接追随移动的 `main`。

--- a/tests/test_validate_skill_manifest.py
+++ b/tests/test_validate_skill_manifest.py
@@ -26,7 +26,7 @@ class ManifestVersionGateTests(unittest.TestCase):
             REPOSITORY_ROOT / "scripts/validate-skill-manifest.py",
             self.root / "scripts/validate-skill-manifest.py",
         )
-        self.write_manifest("0.1.0")
+        self.write_manifest("0.1.0", "0.1.0")
         self.write_skill("first\n")
         self.git("init")
         self.git("config", "user.name", "Runtime Skills Test")
@@ -52,10 +52,10 @@ class ManifestVersionGateTests(unittest.TestCase):
             encoding="utf-8",
         )
 
-    def write_manifest(self, skill_version: str) -> None:
+    def write_manifest(self, skill_version: str, release_version: str) -> None:
         manifest = {
             "schema_version": 1,
-            "release_version": "0.1.0",
+            "release_version": release_version,
             "repository": {
                 "url": "https://github.com/example/runtime-skills",
                 "channel": "stable",
@@ -94,7 +94,12 @@ class ManifestVersionGateTests(unittest.TestCase):
         self.assertEqual(failed.returncode, 1)
         self.assertIn("version did not increase", failed.stderr)
 
-        self.write_manifest("0.1.1")
+        self.write_manifest("0.1.1", "0.1.0")
+        release_not_bumped = self.validate()
+        self.assertEqual(release_not_bumped.returncode, 1)
+        self.assertIn("release_version did not increase", release_not_bumped.stderr)
+
+        self.write_manifest("0.1.1", "0.1.1")
         passed = self.validate()
         self.assertEqual(passed.returncode, 0, passed.stderr)
 


### PR DESCRIPTION
Closes #12

## Summary

- trigger the Runtime Skill release workflow after relevant changes land on `main`, with `workflow_dispatch` as a recovery path
- derive the release tag from `skills-manifest.json`, create a missing tag and GitHub Release, and remain idempotent when either already exists
- require `release_version` to increase whenever managed Skill content or the synchronization tool changes
- document the automatic release lifecycle and extend validator coverage

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py'` — 8 tests passed
- `python3 scripts/validate-skill-manifest.py --compare-ref origin/main` — passed
- `git diff --check` — passed
- `node --check astro.config.mjs` — passed

After this PR is merged, the `main` workflow should bootstrap the missing `v0.1.0` tag and GitHub Release automatically.